### PR TITLE
[WJ-1244] Add the concept of the "layout" to ftml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = ["parser-implementations"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "1.24.0"
+version = "1.25.0"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2021"
 

--- a/src/includes/test.rs
+++ b/src/includes/test.rs
@@ -19,11 +19,12 @@
  */
 
 use super::{include, DebugIncluder, PageRef};
+use crate::layout::Layout;
 use crate::settings::{WikitextMode, WikitextSettings};
 
 #[test]
 fn includes() {
-    let settings = WikitextSettings::from_mode(WikitextMode::Page);
+    let settings = WikitextSettings::from_mode(WikitextMode::Page, Layout::Wikidot);
 
     macro_rules! test {
         ($text:expr, $expected:expr $(,)?) => {{

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,0 +1,48 @@
+/*
+ * layout.rs
+ *
+ * ftml - Library to parse Wikidot text
+ * Copyright (C) 2019-2024 Wikijump Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// Describes the desired (HTML) DOM layout to be emitted.
+///
+/// This is used as a transition mechanism between our dependencies on the pecularities
+/// of old, legacy Wikidot HTML generation and a newer better system we are calling the
+/// "Wikijump" layout.
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum Layout {
+    Wikidot,
+    Wikijump,
+}
+
+impl Layout {
+    #[inline]
+    pub fn legacy(self) -> bool {
+        match self {
+            Layout::Wikidot => true,
+            Layout::Wikijump => false,
+        }
+    }
+
+    #[inline]
+    pub fn description(self) -> &'static str {
+        match self {
+            Layout::Wikidot => "Wikidot (legacy)",
+            Layout::Wikijump => "Wikijump",
+        }
+    }
+}

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -23,7 +23,8 @@
 /// This is used as a transition mechanism between our dependencies on the pecularities
 /// of old, legacy Wikidot HTML generation and a newer better system we are calling the
 /// "Wikijump" layout.
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
 pub enum Layout {
     Wikidot,
     Wikijump,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,7 @@ pub mod wasm;
 pub mod data;
 pub mod includes;
 pub mod info;
+pub mod layout;
 pub mod parsing;
 pub mod preproc;
 pub mod render;

--- a/src/parsing/check_step.rs
+++ b/src/parsing/check_step.rs
@@ -19,6 +19,7 @@
  */
 
 use super::{ExtractedToken, ParseError, Parser, Token};
+use crate::layout::Layout;
 
 /// Helper function to assert that the current token matches, then step.
 ///
@@ -49,7 +50,7 @@ fn check_step_fail() {
     use crate::settings::{WikitextMode, WikitextSettings};
 
     let page_info = PageInfo::dummy();
-    let settings = WikitextSettings::from_mode(WikitextMode::Page);
+    let settings = WikitextSettings::from_mode(WikitextMode::Page, Layout::Wikidot);
     let tokenization = crate::tokenize("**Apple** banana");
     let mut parser = Parser::new(&tokenization, &page_info, &settings);
 

--- a/src/parsing/check_step.rs
+++ b/src/parsing/check_step.rs
@@ -19,7 +19,6 @@
  */
 
 use super::{ExtractedToken, ParseError, Parser, Token};
-use crate::layout::Layout;
 
 /// Helper function to assert that the current token matches, then step.
 ///
@@ -47,6 +46,7 @@ pub fn check_step<'r, 't>(
 #[should_panic]
 fn check_step_fail() {
     use crate::data::PageInfo;
+    use crate::layout::Layout;
     use crate::settings::{WikitextMode, WikitextSettings};
 
     let page_info = PageInfo::dummy();

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -23,7 +23,6 @@ use super::prelude::*;
 use super::rule::Rule;
 use super::RULE_PAGE;
 use crate::data::PageInfo;
-use crate::layout::Layout;
 use crate::render::text::TextRender;
 use crate::tokenizer::Tokenization;
 use crate::tree::{
@@ -584,6 +583,7 @@ fn make_shared_vec<T>() -> Rc<RefCell<Vec<T>>> {
 
 #[test]
 fn parser_newline_flag() {
+    use crate::layout::Layout;
     use crate::settings::WikitextMode;
 
     let page_info = PageInfo::dummy();

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -23,6 +23,7 @@ use super::prelude::*;
 use super::rule::Rule;
 use super::RULE_PAGE;
 use crate::data::PageInfo;
+use crate::layout::Layout;
 use crate::render::text::TextRender;
 use crate::tokenizer::Tokenization;
 use crate::tree::{
@@ -586,7 +587,7 @@ fn parser_newline_flag() {
     use crate::settings::WikitextMode;
 
     let page_info = PageInfo::dummy();
-    let settings = WikitextSettings::from_mode(WikitextMode::Page);
+    let settings = WikitextSettings::from_mode(WikitextMode::Page, Layout::Wikidot);
 
     macro_rules! check {
         ($input:expr, $expected_steps:expr $(,)?) => {{

--- a/src/parsing/parser_wrap.rs
+++ b/src/parsing/parser_wrap.rs
@@ -19,7 +19,6 @@
  */
 
 use super::Parser;
-use crate::layout::Layout;
 use crate::tree::AcceptsPartial;
 use std::ops::{Deref, DerefMut};
 
@@ -66,6 +65,7 @@ impl Drop for ParserWrap<'_, '_, '_> {
 #[test]
 fn wrap() {
     use crate::data::PageInfo;
+    use crate::layout::Layout;
     use crate::settings::{WikitextMode, WikitextSettings};
 
     let page_info = PageInfo::dummy();

--- a/src/parsing/parser_wrap.rs
+++ b/src/parsing/parser_wrap.rs
@@ -19,6 +19,7 @@
  */
 
 use super::Parser;
+use crate::layout::Layout;
 use crate::tree::AcceptsPartial;
 use std::ops::{Deref, DerefMut};
 
@@ -68,7 +69,7 @@ fn wrap() {
     use crate::settings::{WikitextMode, WikitextSettings};
 
     let page_info = PageInfo::dummy();
-    let settings = WikitextSettings::from_mode(WikitextMode::Page);
+    let settings = WikitextSettings::from_mode(WikitextMode::Page, Layout::Wikidot);
     let tokens = crate::tokenize("Test input");
     let mut parser = Parser::new(&tokens, &page_info, &settings);
 

--- a/src/render/html/context.rs
+++ b/src/render/html/context.rs
@@ -26,6 +26,7 @@ use super::random::Random;
 use crate::data::PageRef;
 use crate::data::{Backlinks, PageInfo};
 use crate::info;
+use crate::layout::Layout;
 use crate::next_index::{NextIndex, TableOfContentsIndex};
 use crate::render::Handle;
 use crate::settings::WikitextSettings;
@@ -109,7 +110,7 @@ impl<'i, 'h, 'e, 't> HtmlContext<'i, 'h, 'e, 't> {
         // Build and return
         HtmlContext {
             body: String::with_capacity(capacity),
-            meta: Self::initial_metadata(info),
+            meta: Self::initial_metadata(info, settings.layout),
             backlinks: Backlinks::new(),
             info,
             handle,
@@ -127,7 +128,7 @@ impl<'i, 'h, 'e, 't> HtmlContext<'i, 'h, 'e, 't> {
         }
     }
 
-    fn initial_metadata(info: &PageInfo<'i>) -> Vec<HtmlMeta> {
+    fn initial_metadata(info: &PageInfo<'i>, layout: Layout) -> Vec<HtmlMeta> {
         // Initial version, we can tune how the metadata is generated later.
 
         vec![
@@ -139,7 +140,7 @@ impl<'i, 'h, 'e, 't> HtmlContext<'i, 'h, 'e, 't> {
             HtmlMeta {
                 tag_type: HtmlMetaType::Name,
                 name: str!("generator"),
-                value: info::VERSION.clone(),
+                value: format!("{} {}", *info::VERSION, layout.description()),
             },
             HtmlMeta {
                 tag_type: HtmlMetaType::Name,

--- a/src/render/html/mod.rs
+++ b/src/render/html/mod.rs
@@ -41,22 +41,12 @@ use super::prelude;
 use self::attributes::AddedAttributes;
 use self::context::HtmlContext;
 use crate::data::PageInfo;
-use crate::layout::Layout;
 use crate::render::{Handle, Render};
 use crate::settings::WikitextSettings;
 use crate::tree::SyntaxTree;
 
 #[derive(Debug)]
-pub struct HtmlRender {
-    layout: Layout,
-}
-
-impl HtmlRender {
-    #[inline]
-    pub fn new(layout: Layout) -> Self {
-        HtmlRender { layout }
-    }
-}
+pub struct HtmlRender;
 
 impl Render for HtmlRender {
     type Output = HtmlOutput;

--- a/src/render/html/mod.rs
+++ b/src/render/html/mod.rs
@@ -41,12 +41,22 @@ use super::prelude;
 use self::attributes::AddedAttributes;
 use self::context::HtmlContext;
 use crate::data::PageInfo;
+use crate::layout::Layout;
 use crate::render::{Handle, Render};
 use crate::settings::WikitextSettings;
 use crate::tree::SyntaxTree;
 
 #[derive(Debug)]
-pub struct HtmlRender;
+pub struct HtmlRender {
+    layout: Layout,
+}
+
+impl HtmlRender {
+    #[inline]
+    pub fn new(layout: Layout) -> Self {
+        HtmlRender { layout }
+    }
+}
 
 impl Render for HtmlRender {
     type Output = HtmlOutput;

--- a/src/render/html/test.rs
+++ b/src/render/html/test.rs
@@ -20,12 +20,13 @@
 
 use super::prelude::*;
 use super::HtmlRender;
+use crate::layout::Layout;
 use crate::tree::BibliographyList;
 
 #[test]
 fn html() {
     let page_info = PageInfo::dummy();
-    let settings = WikitextSettings::from_mode(WikitextMode::Page);
+    let settings = WikitextSettings::from_mode(WikitextMode::Page, Layout::Wikidot);
     let result = SyntaxTree::from_element_result(
         vec![],
         vec![],

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -22,6 +22,7 @@
 mod prelude {
     pub use super::Render;
     pub use crate::data::PageInfo;
+    pub use crate::layout::Layout;
     pub use crate::settings::{WikitextMode, WikitextSettings};
     pub use crate::tree::{AttributeMap, Container, ContainerType, Element, SyntaxTree};
 }

--- a/src/render/null.rs
+++ b/src/render/null.rs
@@ -24,7 +24,6 @@
 //! and produce a unit value as output.
 
 use super::prelude::*;
-use crate::layout::Layout;
 
 #[derive(Debug)]
 pub struct NullRender;
@@ -44,6 +43,7 @@ impl Render for NullRender {
 
 #[test]
 fn null() {
+    use crate::layout::Layout;
     use crate::tree::BibliographyList;
 
     let page_info = PageInfo::dummy();

--- a/src/render/null.rs
+++ b/src/render/null.rs
@@ -24,6 +24,7 @@
 //! and produce a unit value as output.
 
 use super::prelude::*;
+use crate::layout::Layout;
 
 #[derive(Debug)]
 pub struct NullRender;
@@ -46,7 +47,7 @@ fn null() {
     use crate::tree::BibliographyList;
 
     let page_info = PageInfo::dummy();
-    let settings = WikitextSettings::from_mode(WikitextMode::Page);
+    let settings = WikitextSettings::from_mode(WikitextMode::Page, Layout::Wikidot);
     let result = SyntaxTree::from_element_result(
         vec![],
         vec![],

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -101,7 +101,7 @@ pub struct WikitextSettings {
 
 impl WikitextSettings {
     /// Returns the default settings for the given [`WikitextMode`].
-    pub fn from_mode(mode: WikitextMode, layout: Layout,) -> Self {
+    pub fn from_mode(mode: WikitextMode, layout: Layout) -> Self {
         let interwiki = DEFAULT_INTERWIKI.clone();
 
         match mode {

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -20,6 +20,8 @@
 
 mod interwiki;
 
+use crate::layout::Layout;
+
 pub use self::interwiki::{InterwikiSettings, DEFAULT_INTERWIKI, EMPTY_INTERWIKI};
 
 const DEFAULT_MINIFY_CSS: bool = true;
@@ -30,6 +32,11 @@ const DEFAULT_MINIFY_CSS: bool = true;
 pub struct WikitextSettings {
     /// What mode we're running in.
     pub mode: WikitextMode,
+
+    /// What layout we're targeting.
+    ///
+    /// For instance, generating Wikidot's legacy HTML structure.
+    pub layout: Layout,
 
     /// Whether page-contextual syntax is permitted.
     ///
@@ -94,12 +101,13 @@ pub struct WikitextSettings {
 
 impl WikitextSettings {
     /// Returns the default settings for the given [`WikitextMode`].
-    pub fn from_mode(mode: WikitextMode) -> Self {
+    pub fn from_mode(mode: WikitextMode, layout: Layout,) -> Self {
         let interwiki = DEFAULT_INTERWIKI.clone();
 
         match mode {
             WikitextMode::Page => WikitextSettings {
                 mode,
+                layout,
                 enable_page_syntax: true,
                 use_include_compatibility: false,
                 use_true_ids: true,
@@ -110,6 +118,7 @@ impl WikitextSettings {
             },
             WikitextMode::Draft => WikitextSettings {
                 mode,
+                layout,
                 enable_page_syntax: true,
                 use_include_compatibility: false,
                 use_true_ids: false,
@@ -120,6 +129,7 @@ impl WikitextSettings {
             },
             WikitextMode::ForumPost | WikitextMode::DirectMessage => WikitextSettings {
                 mode,
+                layout,
                 enable_page_syntax: false,
                 use_include_compatibility: false,
                 use_true_ids: false,
@@ -130,6 +140,7 @@ impl WikitextSettings {
             },
             WikitextMode::List => WikitextSettings {
                 mode,
+                layout,
                 enable_page_syntax: true,
                 use_include_compatibility: false,
                 use_true_ids: false,

--- a/src/test/ast.rs
+++ b/src/test/ast.rs
@@ -25,6 +25,7 @@
 
 use super::includer::TestIncluder;
 use crate::data::{PageInfo, ScoreValue};
+use crate::layout::Layout;
 use crate::parsing::ParseError;
 use crate::render::html::HtmlRender;
 use crate::render::Render;
@@ -209,7 +210,7 @@ impl Test<'_> {
             language: cow!("default"),
         };
 
-        let settings = WikitextSettings::from_mode(WikitextMode::Page);
+        let settings = WikitextSettings::from_mode(WikitextMode::Page, Layout::Wikidot);
 
         let (mut text, _pages) =
             crate::include(&self.input, &settings, TestIncluder, || unreachable!())

--- a/src/test/id_prefix.rs
+++ b/src/test/id_prefix.rs
@@ -19,6 +19,7 @@
  */
 
 use crate::data::{PageInfo, ScoreValue};
+use crate::layout::Layout;
 use crate::settings::{WikitextMode, WikitextSettings, EMPTY_INTERWIKI};
 use crate::tree::{
     AttributeMap, Container, ContainerType, Element, ImageSource, ListItem, ListType,
@@ -52,6 +53,7 @@ fn isolate_user_ids() {
 
     let settings = WikitextSettings {
         mode: WikitextMode::Page,
+        layout: Layout::Wikidot,
         enable_page_syntax: true,
         use_true_ids: true,
         use_include_compatibility: false,

--- a/src/test/large.rs
+++ b/src/test/large.rs
@@ -19,6 +19,7 @@
  */
 
 use crate::data::PageInfo;
+use crate::layout::Layout;
 use crate::parsing::{ParseErrorKind, Token};
 use crate::settings::{WikitextMode, WikitextSettings};
 use crate::tree::{Element, SyntaxTree};
@@ -32,7 +33,7 @@ use std::borrow::Cow;
 #[test]
 fn recursion_depth() {
     let page_info = PageInfo::dummy();
-    let settings = WikitextSettings::from_mode(WikitextMode::Page);
+    let settings = WikitextSettings::from_mode(WikitextMode::Page, Layout::Wikidot);
 
     // Build wikitext input
     let mut input = String::new();
@@ -76,7 +77,7 @@ fn large_payload() {
     const ITERATIONS: usize = 500;
 
     let page_info = PageInfo::dummy();
-    let settings = WikitextSettings::from_mode(WikitextMode::Page);
+    let settings = WikitextSettings::from_mode(WikitextMode::Page, Layout::Wikidot);
 
     // Build wikitext input
     let mut input = String::new();

--- a/src/test/prop.rs
+++ b/src/test/prop.rs
@@ -19,6 +19,7 @@
  */
 
 use crate::data::{PageInfo, PageRef};
+use crate::layout::Layout;
 use crate::render::{html::HtmlRender, text::TextRender, Render};
 use crate::settings::{WikitextMode, WikitextSettings};
 use crate::tree::attribute::SAFE_ATTRIBUTES;
@@ -447,7 +448,7 @@ fn render<R: Render>(
     tree: SyntaxTree<'static>,
     page_info: PageInfo<'static>,
 ) -> R::Output {
-    let settings = WikitextSettings::from_mode(WikitextMode::Page);
+    let settings = WikitextSettings::from_mode(WikitextMode::Page, Layout::Wikidot);
     render.render(&tree, &page_info, &settings)
 }
 

--- a/src/test/settings.rs
+++ b/src/test/settings.rs
@@ -19,6 +19,7 @@
  */
 
 use crate::data::PageInfo;
+use crate::layout::Layout;
 use crate::render::{html::HtmlRender, Render};
 use crate::settings::{WikitextMode, WikitextSettings};
 
@@ -36,7 +37,7 @@ fn settings() {
 
     macro_rules! check_individual {
         ($mode:expr, $input:expr, $substring:expr, $contains:expr) => {{
-            let settings = WikitextSettings::from_mode($mode);
+            let settings = WikitextSettings::from_mode($mode, Layout::Wikidot);
             let mut text = str!($input);
             crate::preprocess(&mut text);
 

--- a/src/wasm/settings.rs
+++ b/src/wasm/settings.rs
@@ -69,7 +69,8 @@ impl WikitextSettings {
             _ => return Err(JsValue::from_str("Unknown layout")),
         };
 
-        let settings = RustWikitextSettings::from_mode(rust_mode, rust_layout);
-        Ok(WikitextSettings { inner: Arc::new(settings) })
+        Ok(WikitextSettings {
+            inner: Arc::new(RustWikitextSettings::from_mode(rust_mode, rust_layout)),
+        })
     }
 }

--- a/src/wasm/settings.rs
+++ b/src/wasm/settings.rs
@@ -69,8 +69,7 @@ impl WikitextSettings {
             _ => return Err(JsValue::from_str("Unknown layout")),
         };
 
-        Ok(WikitextSettings {
-            inner: Arc::new(RustWikitextSettings::from_mode(rust_mode, rust_layout)),
-        })
+        let settings = RustWikitextSettings::from_mode(rust_mode, rust_layout);
+        Ok(WikitextSettings { inner: Arc::new(settings) })
     }
 }

--- a/src/wasm/settings.rs
+++ b/src/wasm/settings.rs
@@ -19,6 +19,7 @@
  */
 
 use super::prelude::*;
+use crate::layout::Layout as RustLayout;
 use crate::settings::{
     WikitextMode as RustWikitextMode, WikitextSettings as RustWikitextSettings,
 };
@@ -52,7 +53,7 @@ impl WikitextSettings {
     }
 
     #[wasm_bindgen]
-    pub fn from_mode(mode: String) -> Result<WikitextSettings, JsValue> {
+    pub fn from_mode(mode: String, layout: String) -> Result<WikitextSettings, JsValue> {
         let rust_mode = match mode.as_str() {
             "page" => RustWikitextMode::Page,
             "draft" => RustWikitextMode::Draft,
@@ -62,8 +63,14 @@ impl WikitextSettings {
             _ => return Err(JsValue::from_str("Unknown mode")),
         };
 
+        let rust_layout = match layout.as_str() {
+            "wikidot" => RustLayout::Wikidot,
+            "wikijump" => RustLayout::Wikijump,
+            _ => return Err(JsValue::from_str("Unknown layout")),
+        };
+
         Ok(WikitextSettings {
-            inner: Arc::new(RustWikitextSettings::from_mode(rust_mode)),
+            inner: Arc::new(RustWikitextSettings::from_mode(rust_mode, rust_layout)),
         })
     }
 }


### PR DESCRIPTION
Jira: [WJ-1244](https://scuttle.atlassian.net/browse/WJ-1244)

This adds the concept of "DOM layouts" to ftml. This is to help us resolve an issue we discussed in chat, where we need to emit Wikidot-compatible HTML in order to match with existing themes, but long-term we want a more sane and sensible DOM structure (e.g. using newer HTML5 constructs instead of `<div>` everywhere).

So part of this work involves adding the `Layout` enum to ftml, which we are adding in `WikitextSettings`. Then, as we update things, the `HtmlRender` implementation will be changed to emit different DOM elements depending on which layout is selected.

[WJ-1244]: https://scuttle.atlassian.net/browse/WJ-1244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ