### PR TITLE
Add Layout to crate prelude

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = ["parser-implementations"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "1.25.0"
+version = "1.25.1"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2021"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,7 @@ pub use self::utf16::Utf16IndexMap;
 pub mod prelude {
     pub use super::data::{PageInfo, ScoreValue};
     pub use super::includes::{include, Includer};
+    pub use super::layout::Layout;
     pub use super::parsing::{parse, ParseError, ParseResult};
     pub use super::preprocess;
     pub use super::render::Render;


### PR DESCRIPTION
Simple change, this adds the new `Layout` structure added in the last PR to `ftml::prelude` for easy importing.