### PR TITLE
Add FromStr impl for Layout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = ["parser-implementations"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "1.25.1"
+version = "1.26.0"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2021"
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -18,6 +18,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+use std::str::FromStr;
+
 /// Describes the desired (HTML) DOM layout to be emitted.
 ///
 /// This is used as a transition mechanism between our dependencies on the pecularities
@@ -47,3 +49,20 @@ impl Layout {
         }
     }
 }
+
+impl FromStr for Layout {
+    type Err = LayoutError;
+
+    fn from_str(s: &str) -> Result<Self, LayoutError> {
+        if s.eq_ignore_ascii_case("wikidot") {
+            Ok(Layout::Wikidot)
+        } else if s.eq_ignore_ascii_case("wikijump") {
+            Ok(Layout::Wikijump)
+        } else {
+            Err(LayoutError)
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct LayoutError;

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -51,18 +51,52 @@ impl Layout {
 }
 
 impl FromStr for Layout {
-    type Err = LayoutError;
+    type Err = LayoutParseError;
 
-    fn from_str(s: &str) -> Result<Self, LayoutError> {
+    fn from_str(s: &str) -> Result<Self, LayoutParseError> {
         if s.eq_ignore_ascii_case("wikidot") {
             Ok(Layout::Wikidot)
         } else if s.eq_ignore_ascii_case("wikijump") {
             Ok(Layout::Wikijump)
         } else {
-            Err(LayoutError)
+            Err(LayoutParseError)
         }
     }
 }
 
 #[derive(Debug)]
-pub struct LayoutError;
+pub struct LayoutParseError;
+
+#[test]
+fn test_layout() {
+    macro_rules! check {
+        ($input:expr, $expected:ident $(,)?) => {{
+            let actual: Layout = $input.parse().expect("Invalid layout string");
+            let expected = Layout::$expected;
+
+            assert_eq!(
+                actual, expected,
+                "Actual layout enum doesn't match expected",
+            );
+        }};
+    }
+
+    macro_rules! check_err {
+        ($input:expr $(,)?) => {{
+            let result: Result<Layout, LayoutParseError> = $input.parse();
+            result.expect_err("Unexpected valid layout string");
+        }};
+    }
+
+    check!("wikidot", Wikidot);
+    check!("Wikidot", Wikidot);
+    check!("WIKIDOT", Wikidot);
+
+    check!("wikijump", Wikijump);
+    check!("Wikijump", Wikijump);
+    check!("WIKIJUMP", Wikijump);
+
+    check_err!("invalid");
+    check_err!("XXX");
+    check_err!("foobar");
+}

--- a/src/parsing/rule/impls/block/blocks/mod.rs
+++ b/src/parsing/rule/impls/block/blocks/mod.rs
@@ -25,7 +25,7 @@ mod prelude {
     pub use crate::parsing::ParseError;
     pub use crate::tree::{Container, ContainerType, Element};
 
-    #[cfg(debug)]
+    #[cfg(debug_assertions)]
     pub fn assert_generic_name(
         expected_names: &[&str],
         actual_name: &str,
@@ -42,7 +42,7 @@ mod prelude {
         );
     }
 
-    #[cfg(not(debug))]
+    #[cfg(not(debug_assertions))]
     #[inline]
     pub fn assert_generic_name(_: &[&str], _: &str, _: &str) {}
 

--- a/src/parsing/rule/impls/block/blocks/ruby.rs
+++ b/src/parsing/rule/impls/block/blocks/ruby.rs
@@ -97,8 +97,8 @@ fn parse_block<'r, 't>(
 
     // Ensure it contains no partials
     cfg_if! {
-        if #[cfg(debug)] {
-            for element in elements {
+        if #[cfg(debug_assertions)] {
+            for element in &elements {
                 if let Element::Partial(_) = element {
                     panic!("Found partial after conversion");
                 }


### PR DESCRIPTION
This implements [`FromStr`](https://doc.rust-lang.org/stable/std/str/trait.FromStr.html), which allows us to do `string_value.parse()` to get a `Layout` enum, consistently parsing it for us.

It also fixes the `#[cfg]` conditions to correctly use `debug_assertions`, the actual compilation flag.