### PR TITLE
Add Layout::value() method for string enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = ["parser-implementations"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "1.26.0"
+version = "1.26.1"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2021"
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -34,6 +34,14 @@ pub enum Layout {
 
 impl Layout {
     #[inline]
+    pub fn value(self) -> &'static str {
+        match self {
+            Layout::Wikidot => "wikidot",
+            Layout::Wikijump => "wikijump",
+        }
+    }
+
+    #[inline]
     pub fn legacy(self) -> bool {
         match self {
             Layout::Wikidot => true,


### PR DESCRIPTION
Acts as the reverse of `.parse()` for layouts.