### PR TITLE
Upgrade to actions/cache@v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
           toolchain: stable
 
       - name: Cargo Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -72,7 +72,7 @@ jobs:
           version: latest
 
       - name: Cargo Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -102,7 +102,7 @@ jobs:
           toolchain: stable
 
       - name: Cargo Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -144,7 +144,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cargo Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/config.yaml
+++ b/.github/workflows/config.yaml
@@ -29,7 +29,7 @@ jobs:
           python-version: 3.9
 
       - name: Pip Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/pip


### PR DESCRIPTION
Required by https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/