### PR TITLE
Remove unused lifetimes to address clippy lint.

### DIFF
--- a/src/data/backlinks.rs
+++ b/src/data/backlinks.rs
@@ -29,7 +29,7 @@ pub struct Backlinks<'a> {
     pub external_links: Vec<Cow<'a, str>>,
 }
 
-impl<'a> Backlinks<'a> {
+impl Backlinks<'_> {
     #[inline]
     pub fn new() -> Self {
         Backlinks::default()

--- a/src/parsing/parser_wrap.rs
+++ b/src/parsing/parser_wrap.rs
@@ -42,7 +42,7 @@ impl<'p, 'r, 't> ParserWrap<'p, 'r, 't> {
     }
 }
 
-impl<'p, 'r, 't> Deref for ParserWrap<'p, 'r, 't> {
+impl<'r, 't> Deref for ParserWrap<'_, 'r, 't> {
     type Target = Parser<'r, 't>;
 
     fn deref(&self) -> &Parser<'r, 't> {
@@ -50,7 +50,7 @@ impl<'p, 'r, 't> Deref for ParserWrap<'p, 'r, 't> {
     }
 }
 
-impl<'p, 'r, 't> DerefMut for ParserWrap<'p, 'r, 't> {
+impl<'r, 't> DerefMut for ParserWrap<'_, 'r, 't> {
     fn deref_mut(&mut self) -> &mut Parser<'r, 't> {
         self.parser
     }

--- a/src/parsing/result.rs
+++ b/src/parsing/result.rs
@@ -44,7 +44,7 @@ where
     _text_marker: PhantomData<&'t str>,
 }
 
-impl<'r, 't, T> ParseSuccess<'r, 't, T> {
+impl<T> ParseSuccess<'_, '_, T> {
     #[inline]
     pub fn new(item: T, errors: Vec<ParseError>, paragraph_safe: bool) -> Self {
         ParseSuccess {
@@ -111,7 +111,7 @@ impl<'r, 't, T> ParseSuccess<'r, 't, T> {
     }
 }
 
-impl<'r, 't> ParseSuccess<'r, 't, Elements<'t>> {
+impl<'t> ParseSuccess<'_, 't, Elements<'t>> {
     pub fn check_partials(&self, parser: &Parser) -> Result<(), ParseError> {
         for element in &self.item {
             // This check only applies if the element is a partial.
@@ -128,7 +128,7 @@ impl<'r, 't> ParseSuccess<'r, 't, Elements<'t>> {
     }
 }
 
-impl<'r, 't> ParseSuccess<'r, 't, ()> {
+impl ParseSuccess<'_, '_, ()> {
     #[inline]
     pub fn into_errors(self) -> Vec<ParseError> {
         self.errors

--- a/src/parsing/token/mod.rs
+++ b/src/parsing/token/mod.rs
@@ -46,7 +46,7 @@ pub struct ExtractedToken<'a> {
     pub span: Range<usize>,
 }
 
-impl<'a> ExtractedToken<'a> {
+impl ExtractedToken<'_> {
     /// Returns a new object with the same values, except with span refering to the byte indicies
     /// of the text if it were in UTF-16 rather than in UTF-8.
     #[must_use]

--- a/src/render/html/builder.rs
+++ b/src/render/html/builder.rs
@@ -292,7 +292,7 @@ impl<'c, 'i, 'h, 'e, 't> HtmlBuilderTag<'c, 'i, 'h, 'e, 't> {
     }
 }
 
-impl<'c, 'i, 'h, 'e, 't> Drop for HtmlBuilderTag<'c, 'i, 'h, 'e, 't> {
+impl Drop for HtmlBuilderTag<'_, '_, '_, '_, '_> {
     fn drop(&mut self) {
         if self.in_tag && !self.in_contents {
             self.ctx.push_raw('>');

--- a/src/render/html/context.rs
+++ b/src/render/html/context.rs
@@ -352,14 +352,14 @@ impl<'i, 'h, 'e, 't> From<HtmlContext<'i, 'h, 'e, 't>> for HtmlOutput {
     }
 }
 
-impl<'i, 'h, 'e, 't> Write for HtmlContext<'i, 'h, 'e, 't> {
+impl Write for HtmlContext<'_, '_, '_, '_> {
     #[inline]
     fn write_str(&mut self, s: &str) -> fmt::Result {
         self.buffer().write_str(s)
     }
 }
 
-impl<'i, 'h, 'e, 't> NextIndex<TableOfContentsIndex> for HtmlContext<'i, 'h, 'e, 't> {
+impl NextIndex<TableOfContentsIndex> for HtmlContext<'_, '_, '_, '_> {
     #[inline]
     fn next(&mut self) -> usize {
         self.next_table_of_contents_index()

--- a/src/render/text/context.rs
+++ b/src/render/text/context.rs
@@ -260,7 +260,7 @@ impl<'i, 'h, 'e, 't> From<TextContext<'i, 'h, 'e, 't>> for String {
     }
 }
 
-impl<'i, 'h, 'e, 't> Write for TextContext<'i, 'h, 'e, 't>
+impl<'e, 't> Write for TextContext<'_, '_, 'e, 't>
 where
     'e: 't,
 {

--- a/src/tree/attribute/mod.rs
+++ b/src/tree/attribute/mod.rs
@@ -125,7 +125,7 @@ impl<'t> AttributeMap<'t> {
     }
 }
 
-impl<'t> Debug for AttributeMap<'t> {
+impl Debug for AttributeMap<'_> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.inner.fmt(f)

--- a/src/tree/code.rs
+++ b/src/tree/code.rs
@@ -29,7 +29,7 @@ pub struct CodeBlock<'t> {
     pub name: Option<Cow<'t, str>>,
 }
 
-impl<'t> CodeBlock<'t> {
+impl CodeBlock<'_> {
     pub fn to_owned(&self) -> CodeBlock<'static> {
         CodeBlock {
             contents: string_to_owned(&self.contents),


### PR DESCRIPTION
Follow-up from #26, some new clippy lints have appeared since the last PR. This PR resolves them so we get a clean build again.