### PR TITLE
[WJ-1291] Fix unsanitized javascript in anchors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = ["parser-implementations"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "1.27.0"
+version = "1.28.0"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2021"
 

--- a/src/url.rs
+++ b/src/url.rs
@@ -146,6 +146,10 @@ fn detect_dangerous_schemes() {
     check!("irc://irc.scpwiki.com", false);
     check!("javascript:alert(1)", true);
     check!("JAVASCRIPT:alert(1)", true);
+    check!(" javascript:alert(1)", true);
+    check!("java\nscript:alert(1)", true);
+    check!("javascript\t:alert(1)", true);
+    check!("wtf$1:foo", true);
     check!("JaVaScRiPt:alert(document.cookie)", true);
     check!("data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==", true);
     check!("data:text/javascript,alert(1)", true);

--- a/test/anchor-xss-2.txt
+++ b/test/anchor-xss-2.txt
@@ -1,0 +1,1 @@
+My not suspicious link

--- a/test/anchor-xss-3.html
+++ b/test/anchor-xss-3.html
@@ -1,0 +1,1 @@
+<wj-body class="wj-body"><p><a class="wj-anchor" href="#invalid-url">whitespace in xss</a></p></wj-body>

--- a/test/anchor-xss-3.json
+++ b/test/anchor-xss-3.json
@@ -1,0 +1,66 @@
+{
+    "input": "[[a href=\"java\\nscript:alert(1)\"]]whitespace in xss[[/a]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "attributes": {},
+                    "elements": [
+                        {
+                            "element": "anchor",
+                            "data": {
+                                "target": null,
+                                "attributes": {
+                                    "href": "#invalid-url"
+                                },
+                                "elements": [
+                                    {
+                                        "element": "text",
+                                        "data": "whitespace"
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": " "
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": "in"
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": " "
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": "xss"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "element": "footnote-block",
+                "data": {
+                    "title": null,
+                    "hide": false
+                }
+            }
+        ],
+        "html-blocks": [
+        ],
+        "code-blocks": [
+        ],
+        "table-of-contents": [
+        ],
+        "footnotes": [
+        ],
+        "bibliographies": [
+        ]
+    },
+    "errors": [
+    ]
+}

--- a/test/anchor-xss-3.txt
+++ b/test/anchor-xss-3.txt
@@ -1,0 +1,1 @@
+whitespace in xss


### PR DESCRIPTION
The check for prohibiting dangerous schemes, like `javascript:`, could be bypassed by adding whitespace. Browsers would ignore the whitespace, but it would not match the verbatim dangerous scheme check. This PR patches this issue by adding a check that looks to see if there are weird characters (non-alphanumeric/underscore/dash) before the colon, which would indicate the input is potentially troublesome. In this case, it is rejected as a dangerous URL.