### PR TITLE
Downgrade log levels for most items

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = ["parser-implementations"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "1.28.0"
+version = "1.28.1"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2021"
 

--- a/src/includes/mod.rs
+++ b/src/includes/mod.rs
@@ -82,7 +82,7 @@ where
     for mtch in INCLUDE_REGEX.find_iter(input) {
         let start = mtch.start();
 
-        debug!(
+        trace!(
             "Found include regex match (start {}, slice '{}')",
             start,
             mtch.as_str(),

--- a/src/includes/mod.rs
+++ b/src/includes/mod.rs
@@ -66,14 +66,14 @@ where
     F: FnOnce() -> E,
 {
     if !settings.enable_page_syntax {
-        info!("Includes are disabled for this input, skipping");
+        debug!("Includes are disabled for this input, skipping");
 
         let output = str!(input);
         let pages = vec![];
         return Ok((output, pages));
     }
 
-    info!("Finding and replacing all instances of include blocks in text");
+    debug!("Finding and replacing all instances of include blocks in text");
 
     let mut ranges = Vec::new();
     let mut includes = Vec::new();
@@ -124,7 +124,7 @@ where
     for ((range, include), fetched) in joined_iter {
         let (page_ref, variables) = include.into();
 
-        info!(
+        debug!(
             "Replacing range for included page ({}..{})",
             range.start, range.end,
         );

--- a/src/includes/mod.rs
+++ b/src/includes/mod.rs
@@ -73,7 +73,10 @@ where
         return Ok((output, pages));
     }
 
-    debug!("Finding and replacing all instances of include blocks in text");
+    info!(
+        "Inserting text for all include blocks in text ({} bytes)",
+        input.len(),
+    );
 
     let mut ranges = Vec::new();
     let mut includes = Vec::new();

--- a/src/includes/parse.rs
+++ b/src/includes/parse.rs
@@ -66,7 +66,7 @@ pub fn parse_include_block<'t>(
             let first = pairs.next().expect("No pairs returned on successful parse");
             let span = first.as_span();
 
-            info!("Parsed include block");
+            debug!("Parsed include block");
 
             // Convert into an IncludeRef
             let include = process_pairs(first.into_inner())?;

--- a/src/includes/parse.rs
+++ b/src/includes/parse.rs
@@ -86,7 +86,7 @@ fn process_pairs(mut pairs: Pairs<Rule>) -> Result<IncludeRef, IncludeParseError
     let page_raw = pairs.next().ok_or(IncludeParseError)?.as_str();
     let page_ref = PageRef::parse(page_raw)?;
 
-    debug!("Got page for include {page_ref:?}");
+    trace!("Got page for include {page_ref:?}");
     let mut arguments = HashMap::new();
     let mut var_reference = String::new();
 

--- a/src/parsing/collect/container.rs
+++ b/src/parsing/collect/container.rs
@@ -46,7 +46,7 @@ pub fn collect_container<'r, 't>(
     invalid_conditions: &[ParseCondition],
     error_kind: Option<ParseErrorKind>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!(
+    debug!(
         "Trying to consume tokens to produce container {} for {}",
         container_type.name(),
         rule.name(),

--- a/src/parsing/collect/generic.rs
+++ b/src/parsing/collect/generic.rs
@@ -70,7 +70,7 @@ pub fn collect<'p, 'r, 't, F>(
 where
     F: FnMut(&mut Parser<'r, 't>) -> ParseResult<'r, 't, ()>,
 {
-    info!("Trying to collect tokens for rule {}", rule.name());
+    debug!("Trying to collect tokens for rule {}", rule.name());
 
     let mut errors = Vec::new();
     let mut paragraph_safe = true;

--- a/src/parsing/collect/generic.rs
+++ b/src/parsing/collect/generic.rs
@@ -84,7 +84,7 @@ where
 
         // See if the container has ended
         if parser.evaluate_any(close_conditions) {
-            debug!(
+            trace!(
                 "Found ending condition, returning collected elements (token {})",
                 parser.current().token.name(),
             );
@@ -99,7 +99,7 @@ where
 
         // See if the container should be aborted
         if parser.evaluate_any(invalid_conditions) {
-            debug!(
+            trace!(
                 "Found invalid token, aborting container attempt (token {})",
                 parser.current().token.name(),
             );
@@ -109,7 +109,7 @@ where
 
         // See if we've hit the end
         if parser.current().token == Token::InputEnd {
-            debug!("Found end of input, aborting");
+            trace!("Found end of input, aborting");
             return Err(parser.make_err(ParseErrorKind::EndOfInput));
         }
 

--- a/src/parsing/collect/text.rs
+++ b/src/parsing/collect/text.rs
@@ -77,7 +77,7 @@ where
         invalid_conditions,
         error_kind,
         |parser| {
-            debug!("Ingesting token in string span");
+            trace!("Ingesting token in string span");
 
             end = Some(parser.current());
             ok!(true; ())

--- a/src/parsing/collect/text.rs
+++ b/src/parsing/collect/text.rs
@@ -63,7 +63,7 @@ where
     'r: 't,
 {
     // Log collect_text() call
-    info!("Trying to consume tokens to merge into a single string");
+    debug!("Trying to consume tokens to merge into a single string");
 
     let (start, mut end) = (parser.current(), None);
 

--- a/src/parsing/consume.rs
+++ b/src/parsing/consume.rs
@@ -36,7 +36,7 @@ use std::mem;
 /// It will use the fallback if all rules, fail, so the only failure case is if
 /// the end of the input is reached.
 pub fn consume<'r, 't>(parser: &mut Parser<'r, 't>) -> ParseResult<'r, 't, Elements<'t>> {
-    info!(
+    debug!(
         "Running consume attempt (token {}, slice {:?})",
         parser.current().token.name(),
         parser.current().slice,
@@ -56,7 +56,7 @@ pub fn consume<'r, 't>(parser: &mut Parser<'r, 't>) -> ParseResult<'r, 't, Eleme
         let old_remaining = parser.remaining();
         match rule.try_consume(parser) {
             Ok(output) => {
-                info!("Rule {} matched, returning generated result", rule.name());
+                debug!("Rule {} matched, returning generated result", rule.name());
 
                 // If the pointer hasn't moved, we step one token.
                 if parser.same_pointer(old_remaining) {

--- a/src/parsing/consume.rs
+++ b/src/parsing/consume.rs
@@ -46,12 +46,12 @@ pub fn consume<'r, 't>(parser: &mut Parser<'r, 't>) -> ParseResult<'r, 't, Eleme
     // Will fail if we're too many layers in
     parser.depth_increment()?;
 
-    debug!("Looking for valid rules");
+    trace!("Looking for valid rules");
     let mut all_errors = Vec::new();
     let current = parser.current();
 
     for &rule in get_rules_for_token(current) {
-        debug!("Trying rule consumption for tokens (rule {})", rule.name());
+        trace!("Trying rule consumption for tokens (rule {})", rule.name());
 
         let old_remaining = parser.remaining();
         match rule.try_consume(parser) {

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -180,7 +180,7 @@ where
     let mut parser = Parser::new(tokenization, page_info, settings);
 
     // At the top level, we gather elements into paragraphs
-    debug!("Running parser on tokens");
+    info!("Running parser on {} tokens", tokenization.tokens().len());
     let result = gather_paragraphs(&mut parser, RULE_PAGE, NO_CLOSE_CONDITION);
 
     // Build and return

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -97,14 +97,14 @@ where
     // For producing table of contents indexes
     let mut incrementer = Incrementer(0);
 
-    info!("Finished paragraph gathering, matching on consumption");
+    debug!("Finished paragraph gathering, matching on consumption");
     match result {
         Ok(ParseSuccess {
             item: mut elements,
             errors,
             ..
         }) => {
-            info!(
+            debug!(
                 "Finished parsing, producing final syntax tree ({} errors)",
                 errors.len(),
             );
@@ -123,7 +123,7 @@ where
             // Add a footnote block at the end,
             // if the user doesn't have one already
             if !has_footnote_block {
-                info!("No footnote block in elements, appending one");
+                debug!("No footnote block in elements, appending one");
 
                 elements.push(Element::FootnoteBlock {
                     title: None,
@@ -180,7 +180,7 @@ where
     let mut parser = Parser::new(tokenization, page_info, settings);
 
     // At the top level, we gather elements into paragraphs
-    info!("Running parser on tokens");
+    debug!("Running parser on tokens");
     let result = gather_paragraphs(&mut parser, RULE_PAGE, NO_CLOSE_CONDITION);
 
     // Build and return

--- a/src/parsing/paragraph/mod.rs
+++ b/src/parsing/paragraph/mod.rs
@@ -109,13 +109,13 @@ where
                 }
 
                 // Otherwise, produce consumption from this token pointer
-                debug!("Trying to consume tokens to produce element");
+                trace!("Trying to consume tokens to produce element");
                 consume(parser)
             }
         }?
         .into();
 
-        debug!("Tokens consumed to produce element");
+        trace!("Tokens consumed to produce element");
 
         // Add new elements to the list
         push_elements(&mut stack, elements, paragraph_safe);

--- a/src/parsing/paragraph/mod.rs
+++ b/src/parsing/paragraph/mod.rs
@@ -57,7 +57,7 @@ where
     'r: 't,
     F: FnMut(&mut Parser<'r, 't>) -> Result<bool, ParseError>,
 {
-    info!("Gathering paragraphs until ending");
+    debug!("Gathering paragraphs until ending");
 
     // Update parser rule
     parser.set_rule(rule);
@@ -87,7 +87,7 @@ where
 
             // If we've hit a paragraph break, then finish the current paragraph
             Token::ParagraphBreak => {
-                info!("Hit a paragraph break, creating a new paragraph container");
+                debug!("Hit a paragraph break, creating a new paragraph container");
 
                 // Paragraph break -- end the paragraph and start a new one!
                 stack.end_paragraph();
@@ -103,7 +103,7 @@ where
             _ => {
                 if let Some(ref mut close_condition_fn) = close_condition_fn {
                     if close_condition_fn(parser).unwrap_or(false) {
-                        info!("Hit closing condition for paragraphs, terminating token iteration");
+                        debug!("Hit closing condition for paragraphs, terminating token iteration");
                         break;
                     }
                 }

--- a/src/parsing/paragraph/stack.rs
+++ b/src/parsing/paragraph/stack.rs
@@ -52,7 +52,7 @@ impl<'t> ParagraphStack<'t> {
 
     #[inline]
     pub fn push_element(&mut self, element: Element<'t>, paragraph_safe: bool) {
-        info!(
+        debug!(
             "Pushing element {} to stack (paragraph safe: {}",
             element.name(),
             paragraph_safe,
@@ -71,7 +71,7 @@ impl<'t> ParagraphStack<'t> {
 
     #[inline]
     pub fn push_errors(&mut self, errors: &mut Vec<ParseError>) {
-        info!("Pushing errors to stack (length {})", errors.len());
+        debug!("Pushing errors to stack (length {})", errors.len());
         self.errors.append(errors);
     }
 
@@ -126,7 +126,7 @@ impl<'t> ParagraphStack<'t> {
     /// This returns all collected elements, errors, and returns the final
     /// paragraph safety value.
     pub fn into_result<'r>(mut self) -> ParseResult<'r, 't, Vec<Element<'t>>> {
-        info!("Converting paragraph parse stack into ParseResult");
+        debug!("Converting paragraph parse stack into ParseResult");
 
         // Finish current paragraph, if any
         self.end_paragraph();
@@ -156,7 +156,7 @@ impl<'t> ParagraphStack<'t> {
     /// and either have an alternate means of determining paragraph safety, or
     /// statically know what that value would be.
     pub fn into_elements(mut self) -> Vec<Element<'t>> {
-        info!("Converting paragraph parse stack into a Vec<Element>");
+        debug!("Converting paragraph parse stack into a Vec<Element>");
 
         // Finish current paragraph, if any
         self.end_paragraph();

--- a/src/parsing/paragraph/stack.rs
+++ b/src/parsing/paragraph/stack.rs
@@ -84,7 +84,7 @@ impl<'t> ParagraphStack<'t> {
     /// This should only be between lines in the blockquote.
     #[inline]
     pub fn pop_line_break(&mut self) {
-        debug!("Popping last element if Element::LineBreak");
+        trace!("Popping last element if Element::LineBreak");
 
         if let Some(Element::LineBreak) = self.current.last() {
             self.current.pop();
@@ -93,14 +93,14 @@ impl<'t> ParagraphStack<'t> {
 
     /// Creates a paragraph element out of this instance's current elements.
     pub fn build_paragraph(&mut self) -> Option<Element<'t>> {
-        debug!(
+        trace!(
             "Building paragraph from current stack state (length {})",
             self.current.len(),
         );
 
         // Don't create empty paragraphs
         if self.current.is_empty() {
-            debug!("No paragraph created, no pending elements in stack");
+            trace!("No paragraph created, no pending elements in stack");
             return None;
         }
 
@@ -114,7 +114,7 @@ impl<'t> ParagraphStack<'t> {
 
     /// Set the finished field in this struct to the paragraph element.
     pub fn end_paragraph(&mut self) {
-        debug!("Ending the current paragraph to push as a completed element");
+        trace!("Ending the current paragraph to push as a completed element");
 
         if let Some(paragraph) = self.build_paragraph() {
             self.finished.push(paragraph);

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -322,7 +322,7 @@ impl<'r, 't> Parser<'r, 't> {
 
     // State evaluation
     pub fn evaluate(&self, condition: ParseCondition) -> bool {
-        info!(
+        debug!(
             "Evaluating parser condition (token {}, slice '{}', span {}..{})",
             self.current.token.name(),
             self.current.slice,
@@ -369,7 +369,7 @@ impl<'r, 't> Parser<'r, 't> {
 
     #[inline]
     pub fn evaluate_any(&self, conditions: &[ParseCondition]) -> bool {
-        info!(
+        debug!(
             "Evaluating to see if any parser condition is true (conditions length {})",
             conditions.len(),
         );
@@ -382,7 +382,7 @@ impl<'r, 't> Parser<'r, 't> {
     where
         F: FnOnce(&mut Parser<'r, 't>) -> Result<bool, ParseError>,
     {
-        info!("Evaluating closure for parser condition");
+        debug!("Evaluating closure for parser condition");
         f(&mut self.clone()).unwrap_or(false)
     }
 
@@ -390,7 +390,7 @@ impl<'r, 't> Parser<'r, 't> {
     where
         F: FnOnce(&mut Parser<'r, 't>) -> Result<bool, ParseError>,
     {
-        info!("Evaluating closure for parser condition, saving progress on success");
+        debug!("Evaluating closure for parser condition, saving progress on success");
 
         let mut parser = self.clone();
         if f(&mut parser).unwrap_or(false) {
@@ -533,18 +533,18 @@ impl<'r, 't> Parser<'r, 't> {
     }
 
     pub fn get_optional_line_break(&mut self) -> Result<(), ParseError> {
-        info!("Looking for optional line break");
+        debug!("Looking for optional line break");
         self.get_optional_token(Token::LineBreak)
     }
 
     #[inline]
     pub fn get_optional_space(&mut self) -> Result<(), ParseError> {
-        info!("Looking for optional space");
+        debug!("Looking for optional space");
         self.get_optional_token(Token::Whitespace)
     }
 
     pub fn get_optional_spaces_any(&mut self) -> Result<(), ParseError> {
-        info!("Looking for optional spaces (any)");
+        debug!("Looking for optional spaces (any)");
 
         let tokens = &[
             Token::Whitespace,

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -177,7 +177,7 @@ impl<'r, 't> Parser<'r, 't> {
 
     pub fn depth_increment(&mut self) -> Result<(), ParseError> {
         self.depth += 1;
-        debug!("Incrementing recursion depth to {}", self.depth);
+        trace!("Incrementing recursion depth to {}", self.depth);
 
         if self.depth > MAX_RECURSION_DEPTH {
             return Err(self.make_err(ParseErrorKind::RecursionDepthExceeded));
@@ -189,7 +189,7 @@ impl<'r, 't> Parser<'r, 't> {
     #[inline]
     pub fn depth_decrement(&mut self) {
         self.depth -= 1;
-        debug!("Decrementing recursion depth to {}", self.depth);
+        trace!("Decrementing recursion depth to {}", self.depth);
     }
 
     #[inline]
@@ -334,7 +334,7 @@ impl<'r, 't> Parser<'r, 't> {
             ParseCondition::CurrentToken(token) => self.current.token == token,
             ParseCondition::TokenPair(current, next) => {
                 if self.current().token != current {
-                    debug!(
+                    trace!(
                         "Current token in pair doesn't match, failing (expected '{}', actual '{}')",
                         current.name(),
                         self.current().token.name(),
@@ -345,7 +345,7 @@ impl<'r, 't> Parser<'r, 't> {
                 match self.look_ahead(0) {
                     Some(actual) => {
                         if actual.token != next {
-                            debug!(
+                            trace!(
                                 "Second token in pair doesn't match, failing (expected {}, actual {})",
                                 next.name(),
                                 actual.token.name(),
@@ -354,7 +354,7 @@ impl<'r, 't> Parser<'r, 't> {
                         }
                     }
                     None => {
-                        debug!(
+                        trace!(
                             "Second token in pair doesn't exist (token {})",
                             next.name(),
                         );
@@ -434,7 +434,7 @@ impl<'r, 't> Parser<'r, 't> {
     /// Move the token pointer forward one step.
     #[inline]
     pub fn step(&mut self) -> Result<&'r ExtractedToken<'t>, ParseError> {
-        debug!("Stepping to the next token");
+        trace!("Stepping to the next token");
 
         // Set the start-of-line flag.
         self.start_of_line = matches!(
@@ -473,7 +473,7 @@ impl<'r, 't> Parser<'r, 't> {
     /// For instance, submitting `0` will yield the first item of `parser.remaining()`.
     #[inline]
     pub fn look_ahead(&self, offset: usize) -> Option<&'r ExtractedToken<'t>> {
-        debug!("Looking ahead to a token (offset {offset})");
+        trace!("Looking ahead to a token (offset {offset})");
         self.remaining.get(offset)
     }
 
@@ -510,7 +510,7 @@ impl<'r, 't> Parser<'r, 't> {
         token: Token,
         kind: ParseErrorKind,
     ) -> Result<&'t str, ParseError> {
-        debug!("Looking for token {} (error {})", token.name(), kind.name());
+        trace!("Looking for token {} (error {})", token.name(), kind.name());
 
         let current = self.current();
         if current.token == token {
@@ -523,7 +523,7 @@ impl<'r, 't> Parser<'r, 't> {
     }
 
     pub fn get_optional_token(&mut self, token: Token) -> Result<(), ParseError> {
-        debug!("Looking for optional token {}", token.name());
+        trace!("Looking for optional token {}", token.name());
 
         if self.current().token == token {
             self.step()?;

--- a/src/parsing/rule/impls/anchor.rs
+++ b/src/parsing/rule/impls/anchor.rs
@@ -37,7 +37,7 @@ pub const RULE_ANCHOR: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Trying to create a named anchor");
+    debug!("Trying to create a named anchor");
     check_step(parser, Token::LeftBlockAnchor)?;
 
     // Requires a space before the name

--- a/src/parsing/rule/impls/bibcite.rs
+++ b/src/parsing/rule/impls/bibcite.rs
@@ -29,7 +29,7 @@ pub const RULE_BIBCITE: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Trying to create bibcite element");
+    debug!("Trying to create bibcite element");
     check_step(parser, Token::LeftParentheses)?;
 
     // This is like a poor man's block, it's "((bibcite <label>))"

--- a/src/parsing/rule/impls/block/blocks/align.rs
+++ b/src/parsing/rule/impls/block/blocks/align.rs
@@ -63,7 +63,7 @@ pub fn parse_alignment_block<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!(
+    debug!(
         "Parsing alignment block (name '{}', block-rule '{}', alignment '{}', in-head {})",
         name,
         block_rule.name,

--- a/src/parsing/rule/impls/block/blocks/anchor.rs
+++ b/src/parsing/rule/impls/block/blocks/anchor.rs
@@ -38,7 +38,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing anchor block (name '{name}', in-head {in_head}, star {flag_star})");
+    debug!("Parsing anchor block (name '{name}', in-head {in_head}, star {flag_star})");
     assert_block_name(&BLOCK_ANCHOR, name);
 
     let arguments = parser.get_head_map(&BLOCK_ANCHOR, in_head)?;

--- a/src/parsing/rule/impls/block/blocks/bibcite.rs
+++ b/src/parsing/rule/impls/block/blocks/bibcite.rs
@@ -36,7 +36,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing bibcite block (name '{name}', in-head {in_head}, score {flag_score})");
+    debug!("Parsing bibcite block (name '{name}', in-head {in_head}, score {flag_score})");
     assert!(!flag_star, "Bibcite doesn't allow star flag");
     assert_block_name(&BLOCK_BIBCITE, name);
 

--- a/src/parsing/rule/impls/block/blocks/bibcite.rs
+++ b/src/parsing/rule/impls/block/blocks/bibcite.rs
@@ -36,7 +36,9 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!("Parsing bibcite block (name '{name}', in-head {in_head}, score {flag_score})");
+    debug!(
+        "Parsing bibcite block (name '{name}', in-head {in_head}, score {flag_score})",
+    );
     assert!(!flag_star, "Bibcite doesn't allow star flag");
     assert_block_name(&BLOCK_BIBCITE, name);
 

--- a/src/parsing/rule/impls/block/blocks/bibliography.rs
+++ b/src/parsing/rule/impls/block/blocks/bibliography.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing bibliography block (name '{name}', in-head {in_head}, score {flag_score})");
+    debug!("Parsing bibliography block (name '{name}', in-head {in_head}, score {flag_score})");
     assert!(!flag_star, "Bibliography doesn't allow star flag");
     assert!(!flag_score, "Bibliography doesn't allow score flag");
     assert_block_name(&BLOCK_BIBLIOGRAPHY, name);

--- a/src/parsing/rule/impls/block/blocks/blockquote.rs
+++ b/src/parsing/rule/impls/block/blocks/blockquote.rs
@@ -36,7 +36,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing blockquote block (in-head {in_head})");
+    debug!("Parsing blockquote block (in-head {in_head})");
     assert!(!flag_star, "Blockquote doesn't allow star flag");
     assert!(!flag_score, "Blockquote doesn't allow score flag");
     assert_block_name(&BLOCK_BLOCKQUOTE, name);

--- a/src/parsing/rule/impls/block/blocks/bold.rs
+++ b/src/parsing/rule/impls/block/blocks/bold.rs
@@ -36,7 +36,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing bold block (name '{name}', in-head {in_head})");
+    debug!("Parsing bold block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "Bold doesn't allow star flag");
     assert!(!flag_score, "Bold doesn't allow score flag");
     assert_block_name(&BLOCK_BOLD, name);

--- a/src/parsing/rule/impls/block/blocks/char.rs
+++ b/src/parsing/rule/impls/block/blocks/char.rs
@@ -54,7 +54,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing character / HTML entity block (in-head {in_head})");
+    debug!("Parsing character / HTML entity block (in-head {in_head})");
     assert!(!flag_star, "Char doesn't allow star flag");
     assert!(!flag_score, "Char doesn't allow score flag");
     assert_block_name(&BLOCK_CHAR, name);

--- a/src/parsing/rule/impls/block/blocks/checkbox.rs
+++ b/src/parsing/rule/impls/block/blocks/checkbox.rs
@@ -36,7 +36,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing checkbox block (name '{name}', in-head {in_head})");
+    debug!("Parsing checkbox block (name '{name}', in-head {in_head})");
     assert!(!flag_score, "Checkbox doesn't allow score flag");
     assert_block_name(&BLOCK_CHECKBOX, name);
 

--- a/src/parsing/rule/impls/block/blocks/code.rs
+++ b/src/parsing/rule/impls/block/blocks/code.rs
@@ -38,7 +38,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing code block (in-head {in_head})");
+    debug!("Parsing code block (in-head {in_head})");
     assert!(!flag_star, "Code doesn't allow star flag");
     assert!(!flag_score, "Code doesn't allow score flag");
     assert_block_name(&BLOCK_CODE, name);

--- a/src/parsing/rule/impls/block/blocks/collapsible.rs
+++ b/src/parsing/rule/impls/block/blocks/collapsible.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing collapsible block (in-head {in_head})");
+    debug!("Parsing collapsible block (in-head {in_head})");
     assert!(!flag_star, "Collapsible doesn't allow star flag");
     assert!(!flag_score, "Collapsible doesn't allow score flag");
     assert_block_name(&BLOCK_COLLAPSIBLE, name);

--- a/src/parsing/rule/impls/block/blocks/date.rs
+++ b/src/parsing/rule/impls/block/blocks/date.rs
@@ -44,7 +44,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing date block (name '{name}', in-head {in_head}, score {flag_score})");
+    debug!("Parsing date block (name '{name}', in-head {in_head}, score {flag_score})");
     assert!(!flag_star, "Date doesn't allow star flag");
     assert!(!flag_score, "Date doesn't allow score flag");
     assert_block_name(&BLOCK_DATE, name);
@@ -97,7 +97,7 @@ fn parse_fn<'r, 't>(
 
 /// Parse a datetime string and produce its time value, as well as possible timezone info.
 fn parse_date(value: &str) -> Result<DateItem, DateParseError> {
-    info!("Parsing possible date value '{value}'");
+    debug!("Parsing possible date value '{value}'");
 
     // Special case, current time
     if value.eq_ignore_ascii_case("now") || value == "." {
@@ -150,7 +150,7 @@ fn parse_timezone(value: &str) -> Result<UtcOffset, DateParseError> {
     static TIMEZONE_REGEX: Lazy<Regex> =
         Lazy::new(|| Regex::new(r"^(\+|-)?([0-9]{1,2}):?([0-9]{2})?$").unwrap());
 
-    info!("Parsing possible timezone value '{value}'");
+    debug!("Parsing possible timezone value '{value}'");
 
     // Try hours / minutes (via regex)
     if let Some(captures) = TIMEZONE_REGEX.captures(value) {

--- a/src/parsing/rule/impls/block/blocks/date.rs
+++ b/src/parsing/rule/impls/block/blocks/date.rs
@@ -101,13 +101,13 @@ fn parse_date(value: &str) -> Result<DateItem, DateParseError> {
 
     // Special case, current time
     if value.eq_ignore_ascii_case("now") || value == "." {
-        debug!("Was now");
+        trace!("Was now");
         return Ok(now().into());
     }
 
     // Try UNIX timestamp (e.g. 1398763929)
     if let Ok(timestamp) = value.parse::<i64>() {
-        debug!("Was UNIX timestamp '{timestamp}'");
+        trace!("Was UNIX timestamp '{timestamp}'");
         let date =
             OffsetDateTime::from_unix_timestamp(timestamp).map_err(|_| DateParseError)?;
 
@@ -116,28 +116,28 @@ fn parse_date(value: &str) -> Result<DateItem, DateParseError> {
 
     // Try datetime strings
     if let Ok(datetime_tz) = OffsetDateTime::parse(value, &Rfc3339) {
-        debug!("Was RFC 3339 datetime string, result '{datetime_tz}'");
+        trace!("Was RFC 3339 datetime string, result '{datetime_tz}'");
         return Ok(datetime_tz.into());
     }
 
     if let Ok(datetime) = PrimitiveDateTime::parse(value, &Iso8601::PARSING) {
-        debug!("Was ISO 8601 datetime string (no timezone), result '{datetime}'");
+        trace!("Was ISO 8601 datetime string (no timezone), result '{datetime}'");
         return Ok(datetime.into());
     }
 
     if let Ok(datetime_tz) = OffsetDateTime::parse(value, &Iso8601::PARSING) {
-        debug!("Was ISO 8601 datetime string, result '{datetime_tz}'");
+        trace!("Was ISO 8601 datetime string, result '{datetime_tz}'");
         return Ok(datetime_tz.into());
     }
 
     if let Ok(datetime_tz) = OffsetDateTime::parse(value, &Rfc2822) {
-        debug!("Was RFC 2822 datetime string, result '{datetime_tz}'");
+        trace!("Was RFC 2822 datetime string, result '{datetime_tz}'");
         return Ok(datetime_tz.into());
     }
 
     // Try date strings
     if let Ok(date) = Date::parse(value, &Iso8601::PARSING) {
-        debug!("Was ISO 8601 date string, result '{date}'");
+        trace!("Was ISO 8601 date string, result '{date}'");
         return Ok(date.into());
     }
 
@@ -184,7 +184,7 @@ fn parse_timezone(value: &str) -> Result<UtcOffset, DateParseError> {
         // Get offset in seconds
         let seconds = sign * (hour * 3600 + minute * 60);
 
-        debug!("Was offset via +HH:MM (sign {sign}, hour {hour}, minute {minute})");
+        trace!("Was offset via +HH:MM (sign {sign}, hour {hour}, minute {minute})");
         return get_offset(seconds);
     }
 
@@ -193,7 +193,7 @@ fn parse_timezone(value: &str) -> Result<UtcOffset, DateParseError> {
     // This is lower-priority than the regex to permit "integer" cases,
     // such as "0800".
     if let Ok(seconds) = value.parse::<i32>() {
-        debug!("Was offset in seconds ({seconds})");
+        trace!("Was offset in seconds ({seconds})");
         return get_offset(seconds);
     }
 

--- a/src/parsing/rule/impls/block/blocks/del.rs
+++ b/src/parsing/rule/impls/block/blocks/del.rs
@@ -36,7 +36,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing deletion block (name '{name}', in-head {in_head})");
+    debug!("Parsing deletion block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "Deletion doesn't allow star flag");
     assert!(!flag_score, "Deletion doesn't allow score flag");
     assert_block_name(&BLOCK_DEL, name);

--- a/src/parsing/rule/impls/block/blocks/div.rs
+++ b/src/parsing/rule/impls/block/blocks/div.rs
@@ -36,7 +36,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing div block (name '{name}', in-head {in_head}, score {flag_score})");
+    debug!("Parsing div block (name '{name}', in-head {in_head}, score {flag_score})");
     assert!(!flag_star, "Div doesn't allow star flag");
     assert_block_name(&BLOCK_DIV, name);
 

--- a/src/parsing/rule/impls/block/blocks/embed.rs
+++ b/src/parsing/rule/impls/block/blocks/embed.rs
@@ -42,7 +42,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing embed block (name '{name}', in-head {in_head})");
+    debug!("Parsing embed block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "Embed doesn't allow star flag");
     assert!(!flag_score, "Embed doesn't allow star flag");
     assert_block_name(&BLOCK_EMBED, name);

--- a/src/parsing/rule/impls/block/blocks/equation_ref.rs
+++ b/src/parsing/rule/impls/block/blocks/equation_ref.rs
@@ -36,7 +36,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing equation reference block (name '{name}', in-head {in_head})");
+    debug!("Parsing equation reference block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "Equation reference doesn't allow start flag");
     assert!(!flag_score, "Equation reference doesn't allow score flag");
     assert_block_name(&BLOCK_EQUATION_REF, name);

--- a/src/parsing/rule/impls/block/blocks/footnote.rs
+++ b/src/parsing/rule/impls/block/blocks/footnote.rs
@@ -46,7 +46,7 @@ fn parse_footnote_ref<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing footnote ref block (in-head {in_head})");
+    debug!("Parsing footnote ref block (in-head {in_head})");
 
     // Check footnote flag
     //
@@ -101,7 +101,7 @@ fn parse_footnote_block<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing footnote list block (in-head {in_head})");
+    debug!("Parsing footnote list block (in-head {in_head})");
     assert!(!flag_star, "Footnote block doesn't allow star flag");
     assert!(!flag_score, "Footnote block doesn't allow score flag");
     assert_block_name(&BLOCK_FOOTNOTE_BLOCK, name);

--- a/src/parsing/rule/impls/block/blocks/hidden.rs
+++ b/src/parsing/rule/impls/block/blocks/hidden.rs
@@ -36,7 +36,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing hidden block (name '{name}', in-head {in_head})");
+    debug!("Parsing hidden block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "Hidden doesn't allow star flag");
     assert!(!flag_score, "Hidden doesn't allow score flag");
     assert_block_name(&BLOCK_HIDDEN, name);

--- a/src/parsing/rule/impls/block/blocks/html.rs
+++ b/src/parsing/rule/impls/block/blocks/html.rs
@@ -36,7 +36,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing HTML block (in-head {in_head})");
+    debug!("Parsing HTML block (in-head {in_head})");
     assert!(!flag_star, "HTML doesn't allow star flag");
     assert!(!flag_score, "HTML doesn't allow score flag");
     assert_block_name(&BLOCK_HTML, name);

--- a/src/parsing/rule/impls/block/blocks/ifcategory.rs
+++ b/src/parsing/rule/impls/block/blocks/ifcategory.rs
@@ -70,7 +70,7 @@ fn parse_fn<'r, 't>(
     let (elements, errors, paragraph_safe) =
         parser.get_body_elements(&BLOCK_IFCATEGORY, false)?.into();
 
-    debug!(
+    trace!(
         "IfCategory conditions parsed (conditions length {}, elements length {})",
         conditions.len(),
         elements.len(),
@@ -78,11 +78,11 @@ fn parse_fn<'r, 't>(
 
     // Return elements based on condition
     let elements = if check_ifcategory(parser.page_info(), &conditions) {
-        debug!("Conditions passed, including elements");
+        trace!("Conditions passed, including elements");
 
         Elements::Multiple(elements)
     } else {
-        debug!("Conditions failed, excluding elements");
+        trace!("Conditions failed, excluding elements");
 
         Elements::None
     };
@@ -96,6 +96,6 @@ pub fn check_ifcategory(info: &PageInfo, conditions: &[ElementCondition]) -> boo
         None => "_default",
     };
 
-    debug!("Checking ifcategory (category '{category}')");
+    trace!("Checking ifcategory (category '{category}')");
     ElementCondition::check(conditions, &[cow!(category)])
 }

--- a/src/parsing/rule/impls/block/blocks/ifcategory.rs
+++ b/src/parsing/rule/impls/block/blocks/ifcategory.rs
@@ -38,7 +38,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing ifcategory block (name '{name}', in-head {in_head})");
+    debug!("Parsing ifcategory block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "IfCategory doesn't allow star flag");
     assert!(!flag_score, "IfCategory doesn't allow score flag");
     assert_block_name(&BLOCK_IFCATEGORY, name);

--- a/src/parsing/rule/impls/block/blocks/iframe.rs
+++ b/src/parsing/rule/impls/block/blocks/iframe.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing iframe block (in-head {in_head})");
+    debug!("Parsing iframe block (in-head {in_head})");
     assert!(!flag_star, "iframe doesn't allow star flag");
     assert!(!flag_score, "iframe doesn't allow score flag");
     assert_block_name(&BLOCK_IFRAME, name);

--- a/src/parsing/rule/impls/block/blocks/iftags.rs
+++ b/src/parsing/rule/impls/block/blocks/iftags.rs
@@ -54,7 +54,7 @@ fn parse_fn<'r, 't>(
     let (elements, errors, paragraph_safe) =
         parser.get_body_elements(&BLOCK_IFTAGS, false)?.into();
 
-    debug!(
+    trace!(
         "IfTags conditions parsed (conditions length {}, elements length {})",
         conditions.len(),
         elements.len(),
@@ -62,11 +62,11 @@ fn parse_fn<'r, 't>(
 
     // Return elements based on condition
     let elements = if check_iftags(parser.page_info(), &conditions) {
-        debug!("Conditions passed, including elements");
+        trace!("Conditions passed, including elements");
 
         Elements::Multiple(elements)
     } else {
-        debug!("Conditions failed, excluding elements");
+        trace!("Conditions failed, excluding elements");
 
         Elements::None
     };
@@ -75,6 +75,6 @@ fn parse_fn<'r, 't>(
 }
 
 pub fn check_iftags(info: &PageInfo, conditions: &[ElementCondition]) -> bool {
-    debug!("Checking iftags");
+    trace!("Checking iftags");
     ElementCondition::check(conditions, &info.tags)
 }

--- a/src/parsing/rule/impls/block/blocks/iftags.rs
+++ b/src/parsing/rule/impls/block/blocks/iftags.rs
@@ -38,7 +38,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing iftags block (name '{name}', in-head {in_head})");
+    debug!("Parsing iftags block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "IfTags doesn't allow star flag");
     assert!(!flag_score, "IfTags doesn't allow score flag");
     assert_block_name(&BLOCK_IFTAGS, name);

--- a/src/parsing/rule/impls/block/blocks/image.rs
+++ b/src/parsing/rule/impls/block/blocks/image.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing image block (name {name}, in-head {in_head})");
+    debug!("Parsing image block (name {name}, in-head {in_head})");
     assert!(!flag_star, "Image doesn't allow star flag");
     assert!(!flag_score, "Image doesn't allow score flag");
     assert_block_name(&BLOCK_IMAGE, name);

--- a/src/parsing/rule/impls/block/blocks/include_elements.rs
+++ b/src/parsing/rule/impls/block/blocks/include_elements.rs
@@ -44,7 +44,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Found invalid include-elements block");
+    debug!("Found invalid include-elements block");
     parser.check_page_syntax()?;
     assert!(!flag_star, "Include (elements) doesn't allow star flag");
     assert!(!flag_score, "Include (elements) doesn't allow score flag");

--- a/src/parsing/rule/impls/block/blocks/include_messy.rs
+++ b/src/parsing/rule/impls/block/blocks/include_messy.rs
@@ -45,7 +45,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     _in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Found invalid include-messy block");
+    debug!("Found invalid include-messy block");
     parser.check_page_syntax()?;
     assert!(!flag_star, "Include (messy) doesn't allow star flag");
     assert!(!flag_score, "Include (messy) doesn't allow score flag");

--- a/src/parsing/rule/impls/block/blocks/ins.rs
+++ b/src/parsing/rule/impls/block/blocks/ins.rs
@@ -36,7 +36,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing insertion block (name '{name}', in-head {in_head})");
+    debug!("Parsing insertion block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "Ins doesn't allow star flag");
     assert!(!flag_score, "Ins doesn't allow score flag");
     assert_block_name(&BLOCK_INS, name);

--- a/src/parsing/rule/impls/block/blocks/invisible.rs
+++ b/src/parsing/rule/impls/block/blocks/invisible.rs
@@ -36,7 +36,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing invisible block (name '{name}', in-head {in_head})");
+    debug!("Parsing invisible block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "Invisible doesn't allow star flag");
     assert!(!flag_score, "Invisible doesn't allow score flag");
     assert_block_name(&BLOCK_INVISIBLE, name);

--- a/src/parsing/rule/impls/block/blocks/italics.rs
+++ b/src/parsing/rule/impls/block/blocks/italics.rs
@@ -36,7 +36,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing italics block (name '{name}', in-head {in_head})");
+    debug!("Parsing italics block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "Italics doesn't allow star flag");
     assert!(!flag_score, "Italics doesn't allow score flag");
     assert_block_name(&BLOCK_ITALICS, name);

--- a/src/parsing/rule/impls/block/blocks/later.rs
+++ b/src/parsing/rule/impls/block/blocks/later.rs
@@ -45,7 +45,7 @@ fn parse_fn<'r, 't>(
     _flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing later block (easter egg, in-head {in_head})");
+    debug!("Parsing later block (easter egg, in-head {in_head})");
     assert_block_name(&BLOCK_LATER, name);
     parser.get_head_none(&BLOCK_LATER, in_head)?;
     ok!(text!("later."))

--- a/src/parsing/rule/impls/block/blocks/lines.rs
+++ b/src/parsing/rule/impls/block/blocks/lines.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing newlines block (in-head {in_head})");
+    debug!("Parsing newlines block (in-head {in_head})");
     assert!(!flag_star, "Lines doesn't allow star flag");
     assert!(!flag_score, "Lines doesn't allow score flag");
     assert_block_name(&BLOCK_LINES, name);

--- a/src/parsing/rule/impls/block/blocks/list.rs
+++ b/src/parsing/rule/impls/block/blocks/list.rs
@@ -95,7 +95,7 @@ fn parse_list_block<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!(
+    debug!(
         "Parsing list block (name '{}', rule {}, list type {}, in-head {}, score {})",
         name,
         block_rule.name,
@@ -185,7 +185,7 @@ fn parse_list_item<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!(
+    debug!(
         "Parsing list item block (name '{}', in-head {}, score {})",
         name, in_head, flag_score,
     );

--- a/src/parsing/rule/impls/block/blocks/mark.rs
+++ b/src/parsing/rule/impls/block/blocks/mark.rs
@@ -36,7 +36,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing highlight block (name '{name}', in-head {in_head})");
+    debug!("Parsing highlight block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "Mark doesn't allow star flag");
     assert!(!flag_score, "Mark doesn't allow score flag");
     assert_block_name(&BLOCK_MARK, name);

--- a/src/parsing/rule/impls/block/blocks/math.rs
+++ b/src/parsing/rule/impls/block/blocks/math.rs
@@ -36,7 +36,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing math block (name '{name}', in-head {in_head})");
+    debug!("Parsing math block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "User doesn't allow star flag");
     assert!(!flag_score, "User doesn't allow score flag");
     assert_block_name(&BLOCK_MATH, name);

--- a/src/parsing/rule/impls/block/blocks/module/modules/backlinks.rs
+++ b/src/parsing/rule/impls/block/blocks/module/modules/backlinks.rs
@@ -31,7 +31,7 @@ fn parse_fn<'r, 't>(
     name: &'t str,
     mut arguments: Arguments<'t>,
 ) -> ParseResult<'r, 't, ModuleParseOutput<'t>> {
-    info!("Parsing backlinks module");
+    debug!("Parsing backlinks module");
     assert_module_name(&MODULE_BACKLINKS, name);
 
     let page = arguments.get("page");

--- a/src/parsing/rule/impls/block/blocks/module/modules/categories.rs
+++ b/src/parsing/rule/impls/block/blocks/module/modules/categories.rs
@@ -31,7 +31,7 @@ fn parse_fn<'r, 't>(
     name: &'t str,
     mut arguments: Arguments<'t>,
 ) -> ParseResult<'r, 't, ModuleParseOutput<'t>> {
-    info!("Parsing categories module");
+    debug!("Parsing categories module");
     assert_module_name(&MODULE_CATEGORIES, name);
 
     let include_hidden = arguments

--- a/src/parsing/rule/impls/block/blocks/module/modules/css.rs
+++ b/src/parsing/rule/impls/block/blocks/module/modules/css.rs
@@ -31,7 +31,7 @@ fn parse_fn<'r, 't>(
     name: &'t str,
     _arguments: Arguments<'t>,
 ) -> ParseResult<'r, 't, ModuleParseOutput<'t>> {
-    info!("Parsing categories module");
+    debug!("Parsing categories module");
     assert_module_name(&MODULE_CSS, name);
 
     let css = parser.get_body_text(&BLOCK_MODULE)?;

--- a/src/parsing/rule/impls/block/blocks/module/modules/join.rs
+++ b/src/parsing/rule/impls/block/blocks/module/modules/join.rs
@@ -31,7 +31,7 @@ fn parse_fn<'r, 't>(
     name: &'t str,
     mut arguments: Arguments<'t>,
 ) -> ParseResult<'r, 't, ModuleParseOutput<'t>> {
-    info!("Parsing join module");
+    debug!("Parsing join module");
     assert_module_name(&MODULE_JOIN, name);
 
     let button_text = arguments.get("button");

--- a/src/parsing/rule/impls/block/blocks/module/modules/page_tree.rs
+++ b/src/parsing/rule/impls/block/blocks/module/modules/page_tree.rs
@@ -31,7 +31,7 @@ fn parse_fn<'r, 't>(
     name: &'t str,
     mut arguments: Arguments<'t>,
 ) -> ParseResult<'r, 't, ModuleParseOutput<'t>> {
-    info!("Parsing PageTree module");
+    debug!("Parsing PageTree module");
     assert_module_name(&MODULE_PAGE_TREE, name);
 
     let root = arguments.get("root");

--- a/src/parsing/rule/impls/block/blocks/module/modules/rate.rs
+++ b/src/parsing/rule/impls/block/blocks/module/modules/rate.rs
@@ -31,7 +31,7 @@ fn parse_fn<'r, 't>(
     name: &'t str,
     _arguments: Arguments<'t>,
 ) -> ParseResult<'r, 't, ModuleParseOutput<'t>> {
-    info!("Parsing categories module");
+    debug!("Parsing categories module");
     assert_module_name(&MODULE_RATE, name);
     ok!(false; Module::Rate)
 }

--- a/src/parsing/rule/impls/block/blocks/module/parser.rs
+++ b/src/parsing/rule/impls/block/blocks/module/parser.rs
@@ -27,7 +27,7 @@ where
 {
     #[inline]
     pub fn set_module(&mut self, module_rule: &ModuleRule) {
-        info!("Running module rule {} for these tokens", module_rule.name);
+        debug!("Running module rule {} for these tokens", module_rule.name);
         self.set_rule(module_rule.rule());
     }
 }

--- a/src/parsing/rule/impls/block/blocks/module/rule.rs
+++ b/src/parsing/rule/impls/block/blocks/module/rule.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing module block (in-head {in_head})");
+    debug!("Parsing module block (in-head {in_head})");
     parser.check_page_syntax()?;
     assert!(!flag_star, "Module doesn't allow star flag");
     assert!(!flag_score, "Module doesn't allow score flag");

--- a/src/parsing/rule/impls/block/blocks/monospace.rs
+++ b/src/parsing/rule/impls/block/blocks/monospace.rs
@@ -36,7 +36,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing monospace block (name '{name}', in-head {in_head})");
+    debug!("Parsing monospace block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "Monospace doesn't allow star flag");
     assert!(!flag_score, "Monospace doesn't allow score flag");
     assert_block_name(&BLOCK_MONOSPACE, name);

--- a/src/parsing/rule/impls/block/blocks/paragraph.rs
+++ b/src/parsing/rule/impls/block/blocks/paragraph.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing paragraph block (name '{name}', in-head {in_head})");
+    debug!("Parsing paragraph block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "Paragraph doesn't allow star flag");
     assert!(!flag_score, "Paragraph doesn't allow score flag");
     assert_block_name(&BLOCK_PARAGRAPH, name);

--- a/src/parsing/rule/impls/block/blocks/radio.rs
+++ b/src/parsing/rule/impls/block/blocks/radio.rs
@@ -36,7 +36,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!(
+    debug!(
         "Parsing radio button block (name '{name}', in-head {in_head}, star {flag_star})",
     );
     assert!(!flag_score, "Radio buttons don't allow score flag");

--- a/src/parsing/rule/impls/block/blocks/ruby.rs
+++ b/src/parsing/rule/impls/block/blocks/ruby.rs
@@ -59,7 +59,7 @@ fn parse_block<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing ruby block (name '{name}', in-head {in_head})");
+    debug!("Parsing ruby block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "Ruby doesn't allow star flag");
     assert!(!flag_score, "Ruby doesn't allow score flag");
     assert_block_name(&BLOCK_RUBY, name);
@@ -128,7 +128,7 @@ fn parse_text<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing ruby text block (name '{name}', in-head {in_head})");
+    debug!("Parsing ruby text block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "Ruby text doesn't allow star flag");
     assert!(!flag_score, "Ruby text doesn't allow score flag");
     assert_block_name(&BLOCK_RT, name);
@@ -158,7 +158,7 @@ fn parse_shortcut<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing ruby shortcut block (name '{name}', in-head {in_head})");
+    debug!("Parsing ruby shortcut block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "Ruby shortcut doesn't allow star flag");
     assert!(!flag_score, "Ruby shortcut doesn't allow score flag");
     assert_block_name(&BLOCK_RB, name);

--- a/src/parsing/rule/impls/block/blocks/size.rs
+++ b/src/parsing/rule/impls/block/blocks/size.rs
@@ -38,7 +38,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing size block (name '{name}', in-head {in_head})");
+    debug!("Parsing size block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "Size doesn't allow star flag");
     assert!(!flag_score, "Size doesn't allow score flag");
     assert_block_name(&BLOCK_SIZE, name);

--- a/src/parsing/rule/impls/block/blocks/span.rs
+++ b/src/parsing/rule/impls/block/blocks/span.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing span block (name '{name}', in-head {in_head})");
+    debug!("Parsing span block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "Span doesn't allow star flag");
     assert_block_name(&BLOCK_SPAN, name);
 

--- a/src/parsing/rule/impls/block/blocks/strikethrough.rs
+++ b/src/parsing/rule/impls/block/blocks/strikethrough.rs
@@ -36,7 +36,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing strikethrough block (name '{name}', in-head {in_head})");
+    debug!("Parsing strikethrough block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "Strikethrough doesn't allow star flag");
     assert!(!flag_score, "Strikethrough doesn't allow score flag");
     assert_block_name(&BLOCK_STRIKETHROUGH, name);

--- a/src/parsing/rule/impls/block/blocks/subscript.rs
+++ b/src/parsing/rule/impls/block/blocks/subscript.rs
@@ -36,7 +36,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing subscript block (name '{name}', in-head {in_head})");
+    debug!("Parsing subscript block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "Subscript doesn't allow star flag");
     assert!(!flag_score, "Subscript doesn't allow score flag");
     assert_block_name(&BLOCK_SUBSCRIPT, name);

--- a/src/parsing/rule/impls/block/blocks/superscript.rs
+++ b/src/parsing/rule/impls/block/blocks/superscript.rs
@@ -36,7 +36,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing superscript block (name '{name}', in-head {in_head})");
+    debug!("Parsing superscript block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "Superscript doesn't allow star flag");
     assert!(!flag_score, "Superscript doesn't allow score flag");
     assert_block_name(&BLOCK_SUPERSCRIPT, name);

--- a/src/parsing/rule/impls/block/blocks/table.rs
+++ b/src/parsing/rule/impls/block/blocks/table.rs
@@ -82,7 +82,7 @@ where
     'r: 't,
     ParsedBlock<'t>: 't,
 {
-    info!("Parsing {description} block (name '{name}', in-head {in_head})");
+    debug!("Parsing {description} block (name '{name}', in-head {in_head})");
     assert!(
         !flag_star,
         "Block for {description} doesn't allow star flag",

--- a/src/parsing/rule/impls/block/blocks/tabs.rs
+++ b/src/parsing/rule/impls/block/blocks/tabs.rs
@@ -49,7 +49,7 @@ fn parse_tabview<'r, 't>(
 ) -> ParseResult<'r, 't, Elements<'t>> {
     let parser = &mut ParserWrap::new(parser, AcceptsPartial::Tab);
 
-    info!("Parsing tabview block (name '{name}', in-head {in_head})");
+    debug!("Parsing tabview block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "Tabview doesn't allow star flag");
     assert!(!flag_score, "Tabview doesn't allow score flag");
     assert_block_name(&BLOCK_TABVIEW, name);
@@ -89,7 +89,7 @@ fn parse_tab<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing tab block (name '{name}', in-head {in_head})");
+    debug!("Parsing tab block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "Tab doesn't allow star flag");
     assert!(!flag_score, "Tab doesn't allow score flag");
     assert_block_name(&BLOCK_TAB, name);

--- a/src/parsing/rule/impls/block/blocks/target.rs
+++ b/src/parsing/rule/impls/block/blocks/target.rs
@@ -38,7 +38,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing target block (name '{name}', in-head {in_head})");
+    debug!("Parsing target block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "Target doesn't allow star flag");
     assert!(!flag_score, "Target doesn't allow score flag");
     assert_block_name(&BLOCK_TARGET, name);

--- a/src/parsing/rule/impls/block/blocks/toc.rs
+++ b/src/parsing/rule/impls/block/blocks/toc.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing table-of-contents block (name '{name}', in-head {in_head})");
+    debug!("Parsing table-of-contents block (name '{name}', in-head {in_head})");
     parser.check_page_syntax()?;
     assert!(!flag_star, "Table of Contents doesn't allow star flag");
     assert!(!flag_score, "Table of Contents doesn't allow score flag");

--- a/src/parsing/rule/impls/block/blocks/underline.rs
+++ b/src/parsing/rule/impls/block/blocks/underline.rs
@@ -36,7 +36,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing underline block (name '{name}', in-head {in_head})");
+    debug!("Parsing underline block (name '{name}', in-head {in_head})");
     assert!(!flag_star, "Underline doesn't allow star flag");
     assert!(!flag_score, "Underline doesn't allow score flag");
     assert_block_name(&BLOCK_UNDERLINE, name);

--- a/src/parsing/rule/impls/block/blocks/user.rs
+++ b/src/parsing/rule/impls/block/blocks/user.rs
@@ -36,7 +36,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing user block (name '{name}', in-head {in_head})");
+    debug!("Parsing user block (name '{name}', in-head {in_head})");
     assert!(!flag_score, "User doesn't allow score flag");
     assert_block_name(&BLOCK_USER, name);
 

--- a/src/parsing/rule/impls/block/parser.rs
+++ b/src/parsing/rule/impls/block/parser.rs
@@ -151,7 +151,7 @@ where
     where
         F: FnMut(&mut Parser<'r, 't>) -> Result<(), ParseError>,
     {
-        debug!("Running generic in block body parser");
+        trace!("Running generic in block body parser");
 
         debug_assert!(
             !block_rule.accepts_names.is_empty(),
@@ -269,7 +269,7 @@ where
         block_rule: &BlockRule,
         in_head: bool,
     ) -> Result<Arguments<'t>, ParseError> {
-        debug!("Looking for key value arguments, then ']]'");
+        trace!("Looking for key value arguments, then ']]'");
 
         let mut map = Arguments::new();
         if in_head {
@@ -355,7 +355,7 @@ where
         block_rule: &BlockRule,
         in_head: bool,
     ) -> Result<(&'t str, Arguments<'t>), ParseError> {
-        debug!("Looking for a name, then key value arguments, then ']]'");
+        trace!("Looking for a name, then key value arguments, then ']]'");
 
         if !in_head {
             warn!("Block is already over, there is no name or arguments");
@@ -426,7 +426,7 @@ where
         block_rule: &BlockRule,
         in_head: bool,
     ) -> Result<(), ParseError> {
-        debug!("Getting end of the head block");
+        trace!("Getting end of the head block");
 
         // If we're still in the head, finish
         if in_head {

--- a/src/parsing/rule/impls/block/parser.rs
+++ b/src/parsing/rule/impls/block/parser.rs
@@ -41,7 +41,7 @@ where
         &mut self,
         flag_star: bool,
     ) -> Result<(&'t str, bool), ParseError> {
-        info!("Looking for identifier");
+        debug!("Looking for identifier");
 
         if flag_star {
             self.get_optional_token(Token::LeftBlockStar)?;
@@ -87,7 +87,7 @@ where
 
     /// Matches an ending block, returning the name present.
     pub fn get_end_block(&mut self) -> Result<&'t str, ParseError> {
-        info!("Looking for end block");
+        debug!("Looking for end block");
 
         self.get_token(Token::LeftBlockEnd, ParseErrorKind::BlockExpectedEnd)?;
         self.get_optional_space()?;
@@ -192,7 +192,7 @@ where
         &mut self,
         block_rule: &BlockRule,
     ) -> Result<&'t str, ParseError> {
-        info!("Getting block body as text (rule {})", block_rule.name);
+        debug!("Getting block body as text (rule {})", block_rule.name);
 
         // State variables for collecting span
         let (start, end) = self.get_body_generic(block_rule, |_| Ok(()))?;
@@ -206,7 +206,7 @@ where
         block_rule: &BlockRule,
         as_paragraphs: bool,
     ) -> ParseResult<'r, 't, Vec<Element<'t>>> {
-        info!(
+        debug!(
             "Getting block body as elements (block rule {}, as-paragraphs {})",
             block_rule.name, as_paragraphs,
         );
@@ -381,7 +381,7 @@ where
     where
         F: FnOnce(&Self, Option<&'t str>) -> Result<T, ParseError>,
     {
-        info!("Looking for a value argument, then ']]' (in-head {in_head})");
+        debug!("Looking for a value argument, then ']]' (in-head {in_head})");
 
         let argument = if in_head {
             // Gather slice of tokens in value
@@ -414,7 +414,7 @@ where
         block_rule: &BlockRule,
         in_head: bool,
     ) -> Result<(), ParseError> {
-        info!("No arguments, looking for end of head block");
+        debug!("No arguments, looking for end of head block");
         self.get_optional_space()?;
         self.get_head_block(block_rule, in_head)?;
         Ok(())
@@ -447,7 +447,7 @@ where
     // Utilities
     #[inline]
     pub fn set_block(&mut self, block_rule: &BlockRule) {
-        info!("Running block rule {} for these tokens", block_rule.name);
+        debug!("Running block rule {} for these tokens", block_rule.name);
         self.set_rule(block_rule.rule());
     }
 }

--- a/src/parsing/rule/impls/block/rule.rs
+++ b/src/parsing/rule/impls/block/rule.rs
@@ -104,7 +104,7 @@ where
     parser.get_optional_space()?;
 
     let (name, in_head) = parser.get_block_name(flag_star)?;
-    debug!("Got block name '{name}' (in head {in_head})");
+    trace!("Got block name '{name}' (in head {in_head})");
 
     let (name, flag_score) = match name.strip_suffix('_') {
         Some(name) => (name, true),

--- a/src/parsing/rule/impls/block/rule.rs
+++ b/src/parsing/rule/impls/block/rule.rs
@@ -44,17 +44,17 @@ pub const RULE_BLOCK_SKIP_NEWLINE: Rule = Rule {
 fn block_regular<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Trying to process a block");
+    debug!("Trying to process a block");
     parse_block(parser, false)
 }
 
 fn block_star<'r, 't>(parser: &mut Parser<'r, 't>) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Trying to process a block (with star flag)");
+    debug!("Trying to process a block (with star flag)");
     parse_block(parser, true)
 }
 
 fn block_skip<'r, 't>(parser: &mut Parser<'r, 't>) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Trying to see if we skip a newline due to upcoming block");
+    debug!("Trying to see if we skip a newline due to upcoming block");
     let current = parser.step()?;
 
     // See if there's a block upcoming
@@ -75,7 +75,7 @@ fn block_skip<'r, 't>(parser: &mut Parser<'r, 't>) -> ParseResult<'r, 't, Elemen
     });
 
     if result {
-        info!("Skipping newline due to upcoming line-terminated block");
+        debug!("Skipping newline due to upcoming line-terminated block");
         ok!(Elements::None)
     } else {
         Err(parser.make_err(ParseErrorKind::RuleFailed))
@@ -91,7 +91,7 @@ fn parse_block<'r, 't>(
 where
     'r: 't,
 {
-    info!("Trying to process a block (star {flag_star})");
+    debug!("Trying to process a block (star {flag_star})");
 
     // Set general rule based on presence of star flag
     parser.set_rule(if flag_star {

--- a/src/parsing/rule/impls/blockquote.rs
+++ b/src/parsing/rule/impls/blockquote.rs
@@ -34,7 +34,7 @@ pub const RULE_BLOCKQUOTE: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Parsing nested native blockquotes");
+    debug!("Parsing nested native blockquotes");
 
     // Context variables
     let mut depths = Vec::new();
@@ -58,7 +58,7 @@ fn try_consume_fn<'r, 't>(
 
         // Check that the depth isn't obscenely deep, to avoid DOS attacks via stack overflow.
         if depth > MAX_BLOCKQUOTE_DEPTH {
-            info!("Native blockquote has a depth ({depth}) greater than the maximum ({MAX_BLOCKQUOTE_DEPTH})! Failing");
+            debug!("Native blockquote has a depth ({depth}) greater than the maximum ({MAX_BLOCKQUOTE_DEPTH})! Failing");
             return Err(parser.make_err(ParseErrorKind::BlockquoteDepthExceeded));
         }
 

--- a/src/parsing/rule/impls/bold.rs
+++ b/src/parsing/rule/impls/bold.rs
@@ -29,7 +29,7 @@ pub const RULE_BOLD: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Trying to create bold (strong) container");
+    debug!("Trying to create bold (strong) container");
     check_step(parser, Token::Bold)?;
     collect_container(
         parser,

--- a/src/parsing/rule/impls/center.rs
+++ b/src/parsing/rule/impls/center.rs
@@ -30,7 +30,7 @@ pub const RULE_CENTER: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Trying to create centered container");
+    debug!("Trying to create centered container");
 
     // Check that the rule has "= "
     macro_rules! next {

--- a/src/parsing/rule/impls/clear_float.rs
+++ b/src/parsing/rule/impls/clear_float.rs
@@ -31,7 +31,7 @@ fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     let current = parser.current();
-    info!("Consuming token to create a clear float");
+    debug!("Consuming token to create a clear float");
 
     let clear_float = match current.token {
         Token::ClearFloatBoth => ClearFloat::Both,

--- a/src/parsing/rule/impls/color.rs
+++ b/src/parsing/rule/impls/color.rs
@@ -35,7 +35,7 @@ pub const RULE_COLOR: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Trying to create color container");
+    debug!("Trying to create color container");
     check_step(parser, Token::Color)?;
 
     // The pattern for color is:

--- a/src/parsing/rule/impls/color.rs
+++ b/src/parsing/rule/impls/color.rs
@@ -53,7 +53,7 @@ fn try_consume_fn<'r, 't>(
         None,
     )?;
 
-    debug!("Retrieved color descriptor, now building container ('{color}')");
+    trace!("Retrieved color descriptor, now building container ('{color}')");
 
     // Build color container
     let (elements, errors, paragraph_safe) = collect_consume(

--- a/src/parsing/rule/impls/comment.rs
+++ b/src/parsing/rule/impls/comment.rs
@@ -29,7 +29,7 @@ pub const RULE_COMMENT: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Consuming tokens until end of comment");
+    debug!("Consuming tokens until end of comment");
 
     check_step(parser, Token::LeftComment)?;
 

--- a/src/parsing/rule/impls/comment.rs
+++ b/src/parsing/rule/impls/comment.rs
@@ -40,25 +40,25 @@ fn try_consume_fn<'r, 't>(
             slice: _slice,
         } = parser.current();
 
-        debug!("Received token '{}' inside comment", token.name());
+        trace!("Received token '{}' inside comment", token.name());
 
         match token {
             // Hit the end of the comment, return
             Token::RightComment => {
-                debug!("Reached end of comment, returning");
+                trace!("Reached end of comment, returning");
                 parser.step()?;
                 return ok!(Elements::None);
             }
 
             // Hit the end of the input, abort
             Token::InputEnd => {
-                debug!("Reached end of input, aborting");
+                trace!("Reached end of input, aborting");
                 return Err(parser.make_err(ParseErrorKind::EndOfInput));
             }
 
             // Consume any other token
             _ => {
-                debug!("Token inside comment received. Discarding.");
+                trace!("Token inside comment received. Discarding.");
                 parser.step()?;
             }
         }

--- a/src/parsing/rule/impls/dash.rs
+++ b/src/parsing/rule/impls/dash.rs
@@ -29,7 +29,7 @@ pub const RULE_DASH: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     _parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Consuming token to create an em dash");
+    debug!("Consuming token to create an em dash");
 
     // — - EM DASH
     ok!(text!("\u{2014}"))

--- a/src/parsing/rule/impls/definition_list.rs
+++ b/src/parsing/rule/impls/definition_list.rs
@@ -71,7 +71,7 @@ fn parse_definition_list<'r, 't>(
 
             match parse_item(sub_parser) {
                 Ok(success) => {
-                    debug!("Retrieved definition list item");
+                    trace!("Retrieved definition list item");
 
                     let (item, at_end) = success.chain(&mut errors, &mut _paragraph_safe);
 
@@ -97,7 +97,7 @@ fn parse_definition_list<'r, 't>(
 fn parse_item<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, (DefinitionListItem<'t>, bool)> {
-    debug!("Trying to parse a definition list item pair");
+    trace!("Trying to parse a definition list item pair");
 
     let mut errors = Vec::new();
     let mut _paragraph_safe = false;

--- a/src/parsing/rule/impls/definition_list.rs
+++ b/src/parsing/rule/impls/definition_list.rs
@@ -37,7 +37,7 @@ pub const RULE_DEFINITION_LIST_SKIP_NEWLINE: Rule = Rule {
 fn skip_newline<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Seeing if we skip due to an upcoming definition list");
+    debug!("Seeing if we skip due to an upcoming definition list");
 
     match parser.next_three_tokens() {
         // It looks like a definition list is upcoming
@@ -53,7 +53,7 @@ fn skip_newline<'r, 't>(
 fn parse_definition_list<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Trying to create a definition list");
+    debug!("Trying to create a definition list");
 
     let mut items = Vec::new();
     let mut errors = Vec::new();

--- a/src/parsing/rule/impls/double_angle.rs
+++ b/src/parsing/rule/impls/double_angle.rs
@@ -30,7 +30,7 @@ fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     let current = parser.current();
-    info!(
+    debug!(
         "Consuming token '{}', to create a left/right double angle quote",
         current.token.name(),
     );

--- a/src/parsing/rule/impls/email.rs
+++ b/src/parsing/rule/impls/email.rs
@@ -29,6 +29,6 @@ pub const RULE_EMAIL: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Consuming token as an email");
+    debug!("Consuming token as an email");
     ok!(Element::Email(cow!(parser.current().slice)))
 }

--- a/src/parsing/rule/impls/header.rs
+++ b/src/parsing/rule/impls/header.rs
@@ -30,7 +30,7 @@ pub const RULE_HEADER: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Trying to create header container");
+    debug!("Trying to create header container");
 
     macro_rules! step {
         ($token:expr) => {{

--- a/src/parsing/rule/impls/horizontal_rule.rs
+++ b/src/parsing/rule/impls/horizontal_rule.rs
@@ -29,7 +29,7 @@ pub const RULE_HORIZONTAL_RULE: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Consuming token to create a horizontal rule");
+    debug!("Consuming token to create a horizontal rule");
     check_step(parser, Token::TripleDash)?;
     parser.get_optional_line_break()?;
     ok!(Element::HorizontalRule)

--- a/src/parsing/rule/impls/italics.rs
+++ b/src/parsing/rule/impls/italics.rs
@@ -29,7 +29,7 @@ pub const RULE_ITALICS: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Trying to create italics (emphasis) container");
+    debug!("Trying to create italics (emphasis) container");
     check_step(parser, Token::Italics)?;
     collect_container(
         parser,

--- a/src/parsing/rule/impls/line_break.rs
+++ b/src/parsing/rule/impls/line_break.rs
@@ -33,7 +33,7 @@ pub const RULE_LINE_BREAK_PARAGRAPH: Rule = Rule {
 };
 
 fn line_break<'r, 't>(parser: &mut Parser<'r, 't>) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Consuming newline token as line break");
+    debug!("Consuming newline token as line break");
 
     // Skip this newline if we're coming up on a rule that starts
     // on its own line.
@@ -64,7 +64,7 @@ fn line_break<'r, 't>(parser: &mut Parser<'r, 't>) -> ParseResult<'r, 't, Elemen
     });
 
     if upcoming_skip {
-        info!("Skipping line break element because of upcoming token");
+        debug!("Skipping line break element because of upcoming token");
         return ok!(Elements::None);
     }
 

--- a/src/parsing/rule/impls/link_anchor.rs
+++ b/src/parsing/rule/impls/link_anchor.rs
@@ -37,7 +37,7 @@ pub const RULE_LINK_ANCHOR: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Trying to create a single-bracket anchor link");
+    debug!("Trying to create a single-bracket anchor link");
     check_step(parser, Token::LeftBracketAnchor)?;
 
     // Gather path for link

--- a/src/parsing/rule/impls/link_anchor.rs
+++ b/src/parsing/rule/impls/link_anchor.rs
@@ -77,7 +77,7 @@ fn try_consume_fn<'r, 't>(
         None,
     )?;
 
-    debug!("Retrieved label ('{label}') for link, building element");
+    trace!("Retrieved label ('{label}') for link, building element");
 
     // Trim label
     let label = label.trim();

--- a/src/parsing/rule/impls/link_single.rs
+++ b/src/parsing/rule/impls/link_single.rs
@@ -60,7 +60,7 @@ fn try_consume_link<'r, 't>(
     rule: Rule,
     target: Option<AnchorTarget>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!(
+    debug!(
         "Trying to create a single-bracket link (target {})",
         match target {
             Some(target) => target.name(),

--- a/src/parsing/rule/impls/link_single.rs
+++ b/src/parsing/rule/impls/link_single.rs
@@ -41,7 +41,7 @@ pub const RULE_LINK_SINGLE_NEW_TAB: Rule = Rule {
 };
 
 fn link<'r, 't>(parser: &mut Parser<'r, 't>) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!("Trying to create a single-bracket link (regular)");
+    trace!("Trying to create a single-bracket link (regular)");
     check_step(parser, Token::LeftBracket)?;
     try_consume_link(parser, RULE_LINK_SINGLE, None)
 }
@@ -49,7 +49,7 @@ fn link<'r, 't>(parser: &mut Parser<'r, 't>) -> ParseResult<'r, 't, Elements<'t>
 fn link_new_tab<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!("Trying to create a single-bracket link (new tab)");
+    trace!("Trying to create a single-bracket link (new tab)");
     check_step(parser, Token::LeftBracketStar)?;
     try_consume_link(parser, RULE_LINK_SINGLE_NEW_TAB, Some(AnchorTarget::NewTab))
 }
@@ -86,7 +86,7 @@ fn try_consume_link<'r, 't>(
         return Err(parser.make_err(ParseErrorKind::InvalidUrl));
     }
 
-    debug!("Retrieved URL '{url}' for link, now fetching label");
+    trace!("Retrieved URL '{url}' for link, now fetching label");
 
     // Gather label for link
     let label = collect_text(
@@ -100,7 +100,7 @@ fn try_consume_link<'r, 't>(
         None,
     )?;
 
-    debug!("Retrieved label for link, now build element (label '{label}')");
+    trace!("Retrieved label for link, now build element (label '{label}')");
 
     // Trim label
     let label = label.trim();

--- a/src/parsing/rule/impls/link_triple.rs
+++ b/src/parsing/rule/impls/link_triple.rs
@@ -45,7 +45,7 @@ pub const RULE_LINK_TRIPLE_NEW_TAB: Rule = Rule {
 };
 
 fn link<'r, 't>(parser: &mut Parser<'r, 't>) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Trying to create a triple-bracket link (regular)");
+    debug!("Trying to create a triple-bracket link (regular)");
     check_step(parser, Token::LeftLink)?;
     try_consume_link(parser, RULE_LINK_TRIPLE, None)
 }
@@ -53,7 +53,7 @@ fn link<'r, 't>(parser: &mut Parser<'r, 't>) -> ParseResult<'r, 't, Elements<'t>
 fn link_new_tab<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Trying to create a triple-bracket link (new tab)");
+    debug!("Trying to create a triple-bracket link (new tab)");
     check_step(parser, Token::LeftLinkStar)?;
     try_consume_link(parser, RULE_LINK_TRIPLE_NEW_TAB, Some(AnchorTarget::NewTab))
 }
@@ -111,7 +111,7 @@ fn build_same<'r, 't>(
     url: &'t str,
     target: Option<AnchorTarget>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Building link with same URL and label (url '{url}')");
+    debug!("Building link with same URL and label (url '{url}')");
 
     // Remove category, if present
     let label = strip_category(url).map(Cow::Borrowed);
@@ -143,7 +143,7 @@ fn build_separate<'r, 't>(
     url: &'t str,
     target: Option<AnchorTarget>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Building link with separate URL and label (url '{url}')");
+    debug!("Building link with separate URL and label (url '{url}')");
 
     // Gather label for link
     let label = collect_text(

--- a/src/parsing/rule/impls/link_triple.rs
+++ b/src/parsing/rule/impls/link_triple.rs
@@ -64,7 +64,7 @@ fn try_consume_link<'r, 't>(
     rule: Rule,
     target: Option<AnchorTarget>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!("Trying to create a triple-bracket link");
+    trace!("Trying to create a triple-bracket link");
 
     // Gather path for link
     let (url, last) = collect_text_keep(
@@ -81,7 +81,7 @@ fn try_consume_link<'r, 't>(
         None,
     )?;
 
-    debug!("Retrieved url for link, now build element (url: '{url}')");
+    trace!("Retrieved url for link, now build element (url: '{url}')");
 
     // Trim text
     let url = url.trim();
@@ -157,7 +157,7 @@ fn build_separate<'r, 't>(
         None,
     )?;
 
-    debug!("Retrieved label for link, now building element (label '{label}')");
+    trace!("Retrieved label for link, now building element (label '{label}')");
 
     // Trim label
     let label = label.trim();

--- a/src/parsing/rule/impls/list.rs
+++ b/src/parsing/rule/impls/list.rs
@@ -86,13 +86,13 @@ fn try_consume_fn<'r, 't>(
         let list_type = match get_list_type(current.token) {
             Some(ltype) => ltype,
             None => {
-                debug!("Didn't find bullet token, couldn't determine list type, ending list iteration");
+                trace!("Didn't find bullet token, couldn't determine list type, ending list iteration");
                 break;
             }
         };
         parser.step()?;
 
-        debug!("Parsing list item '{}'", list_type.name());
+        trace!("Parsing list item '{}'", list_type.name());
 
         // For now, always expect whitespace after the bullet
         let current = parser.current();

--- a/src/parsing/rule/impls/list.rs
+++ b/src/parsing/rule/impls/list.rs
@@ -42,7 +42,7 @@ fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     // We don't know the list type(s) yet, so just log that we're starting
-    info!("Parsing a list");
+    debug!("Parsing a list");
 
     // Context variables
     let mut depths = Vec::new();

--- a/src/parsing/rule/impls/math.rs
+++ b/src/parsing/rule/impls/math.rs
@@ -29,7 +29,7 @@ pub const RULE_MATH: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Trying to create inline math equation");
+    debug!("Trying to create inline math equation");
     check_step(parser, Token::LeftMath)?;
     let source = collect_text(
         parser,

--- a/src/parsing/rule/impls/monospace.rs
+++ b/src/parsing/rule/impls/monospace.rs
@@ -29,7 +29,7 @@ pub const RULE_MONOSPACE: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Trying to create monospace container");
+    debug!("Trying to create monospace container");
     check_step(parser, Token::LeftMonospace)?;
     collect_container(
         parser,

--- a/src/parsing/rule/impls/null.rs
+++ b/src/parsing/rule/impls/null.rs
@@ -29,6 +29,6 @@ pub const RULE_NULL: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     _parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Consuming token and outputting null element");
+    debug!("Consuming token and outputting null element");
     ok!(Elements::None)
 }

--- a/src/parsing/rule/impls/raw.rs
+++ b/src/parsing/rule/impls/raw.rs
@@ -35,7 +35,7 @@ pub const RULE_RAW: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Consuming tokens until end of raw");
+    debug!("Consuming tokens until end of raw");
 
     // Are we in a @@..@@ type raw, or a @<..>@ type?
     let ending_token = match parser.current().token {

--- a/src/parsing/rule/impls/raw.rs
+++ b/src/parsing/rule/impls/raw.rs
@@ -50,7 +50,7 @@ fn try_consume_fn<'r, 't>(
     // * Raw Raw  Raw -> Element::Raw("@@")
     // * Raw ??   Raw -> Element::Raw(slice)
     if ending_token == Token::Raw {
-        debug!("First token is '@@', checking for special cases");
+        trace!("First token is '@@', checking for special cases");
 
         // Get next two tokens. If they don't exist, exit early
         let next_1 = parser.look_ahead_err(0)?;
@@ -60,7 +60,7 @@ fn try_consume_fn<'r, 't>(
         match (next_1.token, next_2.token) {
             // "@@@@@@" -> Element::Raw("@@")
             (Token::Raw, Token::Raw) => {
-                debug!("Found meta-raw (\"@@@@@@\"), returning");
+                trace!("Found meta-raw (\"@@@@@@\"), returning");
                 parser.step_n(3)?;
                 return ok!(raw!("@@"));
             }
@@ -70,11 +70,11 @@ fn try_consume_fn<'r, 't>(
             // So we capture this and return the intended output
             (Token::Raw, Token::Other) => {
                 if next_2.slice == "@" {
-                    debug!("Found single-raw (\"@@@@@\"), returning");
+                    trace!("Found single-raw (\"@@@@@\"), returning");
                     parser.step_n(3)?;
                     return ok!(raw!("@"));
                 } else {
-                    debug!("Found empty raw (\"@@@@\"), followed by other text");
+                    trace!("Found empty raw (\"@@@@\"), followed by other text");
                     parser.step_n(2)?;
                     return ok!(raw!(""));
                 }
@@ -83,20 +83,20 @@ fn try_consume_fn<'r, 't>(
             // "@@@@" -> Element::Raw("")
             // Only consumes two tokens.
             (Token::Raw, _) => {
-                debug!("Found empty raw (\"@@@@\"), returning");
+                trace!("Found empty raw (\"@@@@\"), returning");
                 parser.step_n(2)?;
                 return ok!(raw!(""));
             }
 
             // "@@ \n @@" -> Abort
             (Token::LineBreak, Token::Raw) | (Token::ParagraphBreak, Token::Raw) => {
-                debug!("Found interrupted raw, aborting");
+                trace!("Found interrupted raw, aborting");
                 return Err(parser.make_err(ParseErrorKind::RuleFailed));
             }
 
             // "@@ [something] @@" -> Element::Raw(token)
             (_, Token::Raw) => {
-                debug!("Found single-element raw, returning");
+                trace!("Found single-element raw, returning");
                 parser.step_n(3)?;
                 return ok!(raw!(next_1.slice));
             }
@@ -126,7 +126,7 @@ fn try_consume_fn<'r, 't>(
             span: _span,
         } = parser.current();
 
-        debug!("Received token '{}' inside raw", token.name());
+        trace!("Received token '{}' inside raw", token.name());
 
         // Check token
         match token {

--- a/src/parsing/rule/impls/strikethrough.rs
+++ b/src/parsing/rule/impls/strikethrough.rs
@@ -29,7 +29,7 @@ pub const RULE_STRIKETHROUGH: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Trying to create strikethrough container");
+    debug!("Trying to create strikethrough container");
     check_step(parser, Token::DoubleDash)?;
     collect_container(
         parser,

--- a/src/parsing/rule/impls/subscript.rs
+++ b/src/parsing/rule/impls/subscript.rs
@@ -29,7 +29,7 @@ pub const RULE_SUBSCRIPT: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Trying to create subscript container");
+    debug!("Trying to create subscript container");
     check_step(parser, Token::Subscript)?;
     collect_container(
         parser,

--- a/src/parsing/rule/impls/superscript.rs
+++ b/src/parsing/rule/impls/superscript.rs
@@ -29,7 +29,7 @@ pub const RULE_SUPERSCRIPT: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Trying to create superscript container");
+    debug!("Trying to create superscript container");
     check_step(parser, Token::Superscript)?;
     collect_container(
         parser,

--- a/src/parsing/rule/impls/table.rs
+++ b/src/parsing/rule/impls/table.rs
@@ -39,13 +39,13 @@ pub const RULE_TABLE: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Trying to parse simple table");
+    debug!("Trying to parse simple table");
     let mut rows = Vec::new();
     let mut errors = Vec::new();
     let mut _paragraph_break = false;
 
     'table: loop {
-        info!("Parsing next table row");
+        debug!("Parsing next table row");
 
         let mut cells = Vec::new();
 
@@ -72,7 +72,7 @@ fn try_consume_fn<'r, 't>(
 
         // Loop for each cell in the row
         'row: loop {
-            info!("Parsing next table cell");
+            debug!("Parsing next table cell");
             let mut elements = Vec::new();
             let TableCellStart {
                 align,

--- a/src/parsing/rule/impls/table.rs
+++ b/src/parsing/rule/impls/table.rs
@@ -97,7 +97,7 @@ fn try_consume_fn<'r, 't>(
 
             // Loop for each element in the cell
             'cell: loop {
-                debug!("Parsing next element (length {})", elements.len());
+                trace!("Parsing next element (length {})", elements.len());
                 match parser.next_two_tokens() {
                     // End the cell or row
                     (
@@ -108,7 +108,7 @@ fn try_consume_fn<'r, 't>(
                         | Token::TableColumnRight,
                         Some(next),
                     ) => {
-                        debug!(
+                        trace!(
                             "Ending cell, row, or table (next token '{}')",
                             next.name(),
                         );
@@ -139,7 +139,7 @@ fn try_consume_fn<'r, 't>(
 
                     // Ignore leading whitespace
                     (Token::Whitespace, _) if elements.is_empty() => {
-                        debug!("Ignoring leading whitespace");
+                        trace!("Ignoring leading whitespace");
                         parser.step()?;
                         continue 'cell;
                     }
@@ -155,20 +155,20 @@ fn try_consume_fn<'r, 't>(
                             | Token::TableColumnRight,
                         ),
                     ) => {
-                        debug!("Ignoring trailing whitespace");
+                        trace!("Ignoring trailing whitespace");
                         parser.step()?;
                         continue 'cell;
                     }
 
                     // Invalid tokens
                     (Token::LineBreak | Token::ParagraphBreak | Token::InputEnd, _) => {
-                        debug!("Invalid termination tokens in table, ending");
+                        trace!("Invalid termination tokens in table, ending");
                         finish_table!();
                     }
 
                     // Consume tokens like normal
                     _ => {
-                        debug!("Consuming cell contents as elements");
+                        trace!("Consuming cell contents as elements");
 
                         let new_elements =
                             consume(parser)?.chain(&mut errors, &mut _paragraph_break);

--- a/src/parsing/rule/impls/text.rs
+++ b/src/parsing/rule/impls/text.rs
@@ -29,7 +29,7 @@ pub const RULE_TEXT: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Consuming token as plain text element");
+    debug!("Consuming token as plain text element");
     let ExtractedToken { slice, .. } = parser.current();
     ok!(text!(slice))
 }

--- a/src/parsing/rule/impls/underline.rs
+++ b/src/parsing/rule/impls/underline.rs
@@ -29,7 +29,7 @@ pub const RULE_UNDERLINE: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Trying to create underline container");
+    debug!("Trying to create underline container");
     check_step(parser, Token::Underline)?;
     collect_container(
         parser,

--- a/src/parsing/rule/impls/underscore_line_break.rs
+++ b/src/parsing/rule/impls/underscore_line_break.rs
@@ -29,7 +29,7 @@ pub const RULE_UNDERSCORE_LINE_BREAK: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Trying to parse underscore line break");
+    debug!("Trying to parse underscore line break");
 
     // These can start in two ways:
     // Either a space, or start of line.

--- a/src/parsing/rule/impls/url.rs
+++ b/src/parsing/rule/impls/url.rs
@@ -30,7 +30,7 @@ pub const RULE_URL: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Consuming token as a URL");
+    debug!("Consuming token as a URL");
     let token = parser.current();
     let url = cow!(token.slice);
 

--- a/src/parsing/rule/impls/variable.rs
+++ b/src/parsing/rule/impls/variable.rs
@@ -33,7 +33,7 @@ pub const RULE_VARIABLE: Rule = Rule {
 fn try_consume_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    info!("Consuming token by placing variable contents");
+    debug!("Consuming token by placing variable contents");
 
     let ExtractedToken { slice, .. } = parser.current();
 

--- a/src/parsing/rule/mod.rs
+++ b/src/parsing/rule/mod.rs
@@ -54,7 +54,7 @@ impl Rule {
         self,
         parser: &mut Parser<'r, 't>,
     ) -> ParseResult<'r, 't, Elements<'t>> {
-        info!("Trying to consume for parse rule {}", self.name);
+        debug!("Trying to consume for parse rule {}", self.name);
 
         // Check that the line position matches what the rule wants.
         match self.position {

--- a/src/parsing/token/mod.rs
+++ b/src/parsing/token/mod.rs
@@ -216,7 +216,7 @@ impl Token {
 
         // Get matching Token.
         let token = Token::get_from_rule(rule);
-        debug!("Converting pair '{:?}' into token {}", rule, token.name());
+        trace!("Converting pair '{:?}' into token {}", rule, token.name());
 
         ExtractedToken { token, slice, span }
     }

--- a/src/parsing/token/mod.rs
+++ b/src/parsing/token/mod.rs
@@ -173,11 +173,11 @@ impl Token {
     /// Returns an error if something goes wrong with the parsing process. This will result in the
     /// only [`Token`] being a raw text containing all of the input.
     pub(crate) fn extract_all(text: &str) -> Vec<ExtractedToken> {
-        info!("Running lexer on input");
+        debug!("Running lexer on input");
 
         match TokenLexer::parse(Rule::document, text) {
             Ok(pairs) => {
-                info!("Lexer produced pairs for processing");
+                debug!("Lexer produced pairs for processing");
 
                 // Map pairs to tokens, and add a Token::InputStart at the beginning
                 // Pest already adds a Token::InputEnd at the end

--- a/src/parsing/token/test.rs
+++ b/src/parsing/token/test.rs
@@ -24,7 +24,7 @@ use super::*;
 fn tokens() {
     macro_rules! test {
         ($input:expr, $expected:expr $(,)?) => {{
-            info!("Testing tokens! Input: {}", $input);
+            debug!("Testing tokens! Input: {}", $input);
 
             let expected: Vec<ExtractedToken> = $expected;
             let result = {

--- a/src/preproc/mod.rs
+++ b/src/preproc/mod.rs
@@ -142,9 +142,10 @@ impl Replacer {
 /// This call always succeeds. The return value designates where issues occurred
 /// to allow programmatic determination of where things were not as expected.
 pub fn preprocess(text: &mut String) {
+    info!("Beginning preprocessing of text ({} bytes)", text.len());
     whitespace::substitute(text);
     typography::substitute(text);
-    debug!("Finished preprocessing of text");
+    debug!("Finished preprocessing of text ({} bytes)", text.len());
 }
 
 #[test]

--- a/src/preproc/mod.rs
+++ b/src/preproc/mod.rs
@@ -69,7 +69,7 @@ impl Replacer {
                 ref regex,
                 replacement,
             } => {
-                debug!(
+                trace!(
                     "Running regex regular expression replacement (pattern {}, replacement {})",
                     regex.as_str(),
                     replacement,
@@ -95,7 +95,7 @@ impl Replacer {
                 begin,
                 end,
             } => {
-                debug!(
+                trace!(
                     "Running surround regular expression capture replacement (pattern {}, begin {}, end {})",
                     regex.as_str(),
                     begin,

--- a/src/preproc/mod.rs
+++ b/src/preproc/mod.rs
@@ -144,7 +144,7 @@ impl Replacer {
 pub fn preprocess(text: &mut String) {
     whitespace::substitute(text);
     typography::substitute(text);
-    info!("Finished preprocessing of text");
+    debug!("Finished preprocessing of text");
 }
 
 #[test]

--- a/src/preproc/test.rs
+++ b/src/preproc/test.rs
@@ -31,7 +31,7 @@ where
         string.clear();
         string.push_str(input);
 
-        info!("Testing {filter_name} substitution");
+        debug!("Testing {filter_name} substitution");
 
         substitute(&mut string);
 

--- a/src/preproc/typography.rs
+++ b/src/preproc/typography.rs
@@ -68,7 +68,7 @@ static HORIZONTAL_ELLIPSIS: Lazy<Replacer> = Lazy::new(|| Replacer::RegexReplace
 /// Performs all typographic substitutions in-place in the given text
 pub fn substitute(text: &mut String) {
     let mut buffer = String::new();
-    info!("Performing typography substitutions");
+    debug!("Performing typography substitutions");
 
     macro_rules! replace {
         ($replacer:expr) => {

--- a/src/preproc/whitespace.rs
+++ b/src/preproc/whitespace.rs
@@ -106,7 +106,7 @@ pub fn substitute(text: &mut String) {
 
 /// In-place replaces the leading non-standard spaces (such as nbsp) on each line with standard spaces
 fn replace_leading_spaces(text: &mut String) {
-    debug!("Replacing leading non-standard spaces with regular spaces");
+    trace!("Replacing leading non-standard spaces with regular spaces");
 
     let mut offset = 0;
 

--- a/src/render/debug.rs
+++ b/src/render/debug.rs
@@ -35,7 +35,7 @@ impl Render for DebugRender {
         page_info: &PageInfo,
         settings: &WikitextSettings,
     ) -> String {
-        info!("Running debug logger on syntax tree");
+        debug!("Running debug logger on syntax tree");
         format!("{settings:#?}\n{page_info:#?}\n{tree:#?}")
     }
 }

--- a/src/render/handle.rs
+++ b/src/render/handle.rs
@@ -32,19 +32,19 @@ pub struct Handle;
 impl Handle {
     pub fn render_module(&self, buffer: &mut String, module: &Module) {
         // Modules only render to HTML
-        info!("Rendering module '{}'", module.name());
+        debug!("Rendering module '{}'", module.name());
         str_write!(buffer, "<p>TODO: module {}</p>", module.name());
     }
 
     pub fn get_page_title(&self, _site: &str, _page: &str) -> Option<String> {
-        info!("Fetching page title");
+        debug!("Fetching page title");
 
         // TODO
         Some(format!("TODO: actual title ({_site} {_page})"))
     }
 
     pub fn get_page_exists(&self, _site: &str, _page: &str) -> bool {
-        info!("Checking page existence");
+        debug!("Checking page existence");
 
         // For testing
         #[cfg(test)]
@@ -57,7 +57,7 @@ impl Handle {
     }
 
     pub fn get_user_info<'a>(&self, name: &'a str) -> Option<UserInfo<'a>> {
-        info!("Fetching user info (name '{name}')");
+        debug!("Fetching user info (name '{name}')");
         let mut info = UserInfo::dummy();
         info.user_name = cow!(name);
         info.user_profile_url = Cow::Owned(format!("/user:info/{name}"));
@@ -70,7 +70,7 @@ impl Handle {
         info: &PageInfo,
         settings: &WikitextSettings,
     ) -> Option<Cow<'a, str>> {
-        info!("Getting file link for image");
+        debug!("Getting file link for image");
 
         let (site, page, file): (&str, &str, &str) = match source {
             ImageSource::Url(url) => return Some(Cow::clone(url)),
@@ -130,7 +130,7 @@ impl Handle {
     }
 
     pub fn get_message(&self, language: &str, message: &str) -> &'static str {
-        info!("Fetching message (language {language}, key {message})");
+        debug!("Fetching message (language {language}, key {message})");
 
         let _ = language;
 
@@ -154,7 +154,7 @@ impl Handle {
     }
 
     pub fn post_html(&self, info: &PageInfo, html: &str) -> String {
-        info!("Submitting HTML to create iframe-able snippet");
+        debug!("Submitting HTML to create iframe-able snippet");
 
         let _ = info;
         let _ = html;
@@ -164,7 +164,7 @@ impl Handle {
     }
 
     pub fn post_code(&self, index: NonZeroUsize, code: &str) {
-        info!("Submitting code snippet (index {})", index.get());
+        debug!("Submitting code snippet (index {})", index.get());
 
         let _ = index;
         let _ = code;

--- a/src/render/html/element/bibliography.rs
+++ b/src/render/html/element/bibliography.rs
@@ -22,7 +22,7 @@ use super::prelude::*;
 use crate::tree::Bibliography;
 
 pub fn render_bibcite(ctx: &mut HtmlContext, label: &str, brackets: bool) {
-    info!("Rendering bibliography citation (label {label}, brackets {brackets})");
+    debug!("Rendering bibliography citation (label {label}, brackets {brackets})");
 
     match ctx.get_bibliography_ref(label) {
         // Valid bibliography reference, render it
@@ -106,7 +106,7 @@ pub fn render_bibliography(
     bibliography_index: usize,
     bibliography: &Bibliography,
 ) {
-    info!(
+    debug!(
         "Rendering bibliography block (title {}, items {})",
         title.unwrap_or("<default>"),
         bibliography.slice().len(),

--- a/src/render/html/element/collapsible.rs
+++ b/src/render/html/element/collapsible.rs
@@ -66,7 +66,7 @@ pub fn render_collapsible(ctx: &mut HtmlContext, collapsible: Collapsible) {
         show_bottom,
     } = collapsible;
 
-    info!(
+    debug!(
         "Rendering collapsible (elements length {}, start-open {}, show-text {}, hide-text {}, show-top {}, show-bottom {})",
         elements.len(),
         start_open,

--- a/src/render/html/element/container.rs
+++ b/src/render/html/element/container.rs
@@ -22,7 +22,7 @@ use super::prelude::*;
 use crate::tree::{Container, ContainerType, HtmlTag};
 
 pub fn render_container(ctx: &mut HtmlContext, container: &Container) {
-    info!("Rendering container '{}'", container.ctype().name());
+    debug!("Rendering container '{}'", container.ctype().name());
 
     match container.ctype() {
         // We wrap with <rp> around the <rt> contents
@@ -70,7 +70,7 @@ pub fn render_container_internal(ctx: &mut HtmlContext, container: &Container) {
 }
 
 pub fn render_color(ctx: &mut HtmlContext, color: &str, elements: &[Element]) {
-    info!("Rendering color container (color '{color}')");
+    debug!("Rendering color container (color '{color}')");
 
     ctx.html()
         .span()

--- a/src/render/html/element/definition_list.rs
+++ b/src/render/html/element/definition_list.rs
@@ -22,7 +22,7 @@ use super::prelude::*;
 use crate::tree::DefinitionListItem;
 
 pub fn render_definition_list(ctx: &mut HtmlContext, items: &[DefinitionListItem]) {
-    info!("Rendering definition list (length {})", items.len());
+    debug!("Rendering definition list (length {})", items.len());
 
     ctx.html().dl().inner(|ctx| {
         for DefinitionListItem {

--- a/src/render/html/element/embed.rs
+++ b/src/render/html/element/embed.rs
@@ -22,7 +22,7 @@ use super::prelude::*;
 use crate::tree::Embed;
 
 pub fn render_embed(ctx: &mut HtmlContext, embed: &Embed) {
-    info!(
+    debug!(
         "Rendering embed (variant '{}', url '{}')",
         embed.name(),
         embed.direct_url(),

--- a/src/render/html/element/footnotes.rs
+++ b/src/render/html/element/footnotes.rs
@@ -21,7 +21,7 @@
 use super::prelude::*;
 
 pub fn render_footnote(ctx: &mut HtmlContext) {
-    info!("Rendering footnote reference");
+    debug!("Rendering footnote reference");
 
     let index = ctx.next_footnote_index();
     let id = str!(index);
@@ -76,7 +76,7 @@ pub fn render_footnote(ctx: &mut HtmlContext) {
 }
 
 pub fn render_footnote_block(ctx: &mut HtmlContext, title: Option<&str>) {
-    info!(
+    debug!(
         "Rendering footnote block (title {})",
         title.unwrap_or("<default>"),
     );

--- a/src/render/html/element/iframe.rs
+++ b/src/render/html/element/iframe.rs
@@ -22,7 +22,7 @@ use super::prelude::*;
 use crate::tree::AttributeMap;
 
 pub fn render_iframe(ctx: &mut HtmlContext, url: &str, attributes: &AttributeMap) {
-    info!("Rendering iframe block (url '{url}')");
+    debug!("Rendering iframe block (url '{url}')");
 
     ctx.html().iframe().attr(attr!(
         "src" => url,
@@ -32,7 +32,7 @@ pub fn render_iframe(ctx: &mut HtmlContext, url: &str, attributes: &AttributeMap
 }
 
 pub fn render_html(ctx: &mut HtmlContext, contents: &str) {
-    info!("Rendering html block (submitting to remote for iframe)");
+    debug!("Rendering html block (submitting to remote for iframe)");
 
     // Submit HTML to be hosted on wjfiles, then get back its URL for the iframe.
     let iframe_url = ctx.handle().post_html(ctx.info(), contents);

--- a/src/render/html/element/image.rs
+++ b/src/render/html/element/image.rs
@@ -66,7 +66,7 @@ fn render_image_element(
     alignment: Option<FloatAlignment>,
     attributes: &AttributeMap,
 ) {
-    debug!("Found URL, rendering image (value '{url}')");
+    trace!("Found URL, rendering image (value '{url}')");
 
     let (space, align_class) = match alignment {
         Some(align) => (" ", align.html_class()),
@@ -102,7 +102,7 @@ fn render_image_element(
 }
 
 fn render_image_missing(ctx: &mut HtmlContext) {
-    debug!("Image URL unresolved, missing or error");
+    trace!("Image URL unresolved, missing or error");
 
     let message = ctx
         .handle()

--- a/src/render/html/element/image.rs
+++ b/src/render/html/element/image.rs
@@ -29,7 +29,7 @@ pub fn render_image(
     alignment: Option<FloatAlignment>,
     attributes: &AttributeMap,
 ) {
-    info!(
+    debug!(
         "Rendering image element (source '{}', link {}, alignment {}, float {})",
         source.name(),
         match link {

--- a/src/render/html/element/include.rs
+++ b/src/render/html/element/include.rs
@@ -28,7 +28,7 @@ pub fn render_include(
     variables: &VariableMap,
     elements: &[Element],
 ) {
-    info!("Rendering include (location {location:?})");
+    debug!("Rendering include (location {location:?})");
     ctx.variables_mut().push_scope(variables);
     render_elements(ctx, elements);
     ctx.variables_mut().pop_scope();
@@ -36,7 +36,7 @@ pub fn render_include(
 
 pub fn render_variable(ctx: &mut HtmlContext, name: &str) {
     let value = ctx.variables().get(name);
-    info!(
+    debug!(
         "Rendering variable (name '{}', value '{}'",
         name,
         value.unwrap_or("<none>"),

--- a/src/render/html/element/input.rs
+++ b/src/render/html/element/input.rs
@@ -27,7 +27,7 @@ pub fn render_radio_button(
     checked: bool,
     attributes: &AttributeMap,
 ) {
-    info!("Creating radio button (name '{name}', checked {checked})");
+    debug!("Creating radio button (name '{name}', checked {checked})");
 
     ctx.html().input().attr(attr!(
         "name" => name,
@@ -38,7 +38,7 @@ pub fn render_radio_button(
 }
 
 pub fn render_checkbox(ctx: &mut HtmlContext, checked: bool, attributes: &AttributeMap) {
-    info!("Creating checkbox (checked {checked})");
+    debug!("Creating checkbox (checked {checked})");
 
     ctx.html().input().attr(attr!(
         "type" => "checkbox",

--- a/src/render/html/element/link.rs
+++ b/src/render/html/element/link.rs
@@ -30,7 +30,7 @@ pub fn render_anchor(
     attributes: &AttributeMap,
     target: Option<AnchorTarget>,
 ) {
-    info!("Rendering anchor");
+    debug!("Rendering anchor");
 
     let target_value = match target {
         Some(target) => target.html_attr(),
@@ -55,7 +55,7 @@ pub fn render_link(
     target: Option<AnchorTarget>,
     ltype: LinkType,
 ) {
-    info!("Rendering link '{:?}' (type {})", link, ltype.name());
+    debug!("Rendering link '{:?}' (type {})", link, ltype.name());
     let handle = ctx.handle();
 
     // Add to backlinks

--- a/src/render/html/element/list.rs
+++ b/src/render/html/element/list.rs
@@ -27,7 +27,7 @@ pub fn render_list(
     list_items: &[ListItem],
     attributes: &AttributeMap,
 ) {
-    info!(
+    debug!(
         "Rendering list '{}' (items {})",
         ltype.name(),
         list_items.len(),

--- a/src/render/html/element/math.rs
+++ b/src/render/html/element/math.rs
@@ -36,7 +36,7 @@ cfg_if! {
 }
 
 pub fn render_math_block(ctx: &mut HtmlContext, name: Option<&str>, latex_source: &str) {
-    info!(
+    debug!(
         "Rendering math block (name '{}', source '{}')",
         name.unwrap_or("<none>"),
         latex_source,
@@ -48,7 +48,7 @@ pub fn render_math_block(ctx: &mut HtmlContext, name: Option<&str>, latex_source
 }
 
 pub fn render_math_inline(ctx: &mut HtmlContext, latex_source: &str) {
-    info!("Rendering math inline (source '{latex_source}'");
+    debug!("Rendering math inline (source '{latex_source}'");
     render_latex(ctx, None, None, latex_source, DisplayStyle::Inline);
 }
 
@@ -114,7 +114,7 @@ fn render_latex(
                 if #[cfg(feature = "mathml")] {
                     match latex_to_mathml(latex_source, display) {
                         Ok(mathml) => {
-                            info!("Processed LaTeX -> MathML");
+                            debug!("Processed LaTeX -> MathML");
 
                             // Inject MathML elements
                             ctx.html()
@@ -138,7 +138,7 @@ fn render_latex(
 }
 
 pub fn render_equation_reference(ctx: &mut HtmlContext, name: &str) {
-    info!("Rendering equation reference (name '{name}')");
+    debug!("Rendering equation reference (name '{name}')");
 
     ctx.html()
         .span()

--- a/src/render/html/element/mod.rs
+++ b/src/render/html/element/mod.rs
@@ -75,7 +75,7 @@ use crate::tree::Element;
 use ref_map::*;
 
 pub fn render_elements(ctx: &mut HtmlContext, elements: &[Element]) {
-    info!("Rendering elements (length {})", elements.len());
+    debug!("Rendering elements (length {})", elements.len());
 
     for element in elements {
         render_element(ctx, element);
@@ -89,7 +89,7 @@ pub fn render_element(ctx: &mut HtmlContext, element: &Element) {
         };
     }
 
-    info!("Rendering element '{}'", element.name());
+    debug!("Rendering element '{}'", element.name());
 
     match element {
         Element::Container(container) => render_container(ctx, container),

--- a/src/render/html/element/style.rs
+++ b/src/render/html/element/style.rs
@@ -34,7 +34,7 @@ pub fn render_style(ctx: &mut HtmlContext, input_css: &str) {
         ..Default::default()
     };
 
-    info!("Parsing input CSS ({} bytes)", input_css.len());
+    debug!("Parsing input CSS ({} bytes)", input_css.len());
     let stylesheet = StyleSheet::parse(input_css, parser_options)
         .expect("Produced error with recovery enabled");
 

--- a/src/render/html/element/style.rs
+++ b/src/render/html/element/style.rs
@@ -38,13 +38,13 @@ pub fn render_style(ctx: &mut HtmlContext, input_css: &str) {
     let stylesheet = StyleSheet::parse(input_css, parser_options)
         .expect("Produced error with recovery enabled");
 
-    debug!("Rendering CSS into HTML (minify: {minify})");
+    trace!("Rendering CSS into HTML (minify: {minify})");
     let output_css = match stylesheet.to_css(print_options) {
         Ok(output) => output.code,
         Err(error) => {
             error!("Problem outputting CSS from stylesheet: {error}");
-            debug!("Input CSS:\n{input_css}");
-            debug!("Parsed stylesheet:\n{stylesheet:#?}");
+            trace!("Input CSS:\n{input_css}");
+            trace!("Parsed stylesheet:\n{stylesheet:#?}");
             return;
         }
     };

--- a/src/render/html/element/table.rs
+++ b/src/render/html/element/table.rs
@@ -23,7 +23,7 @@ use crate::tree::Table;
 use std::num::NonZeroU32;
 
 pub fn render_table(ctx: &mut HtmlContext, table: &Table) {
-    info!("Rendering table");
+    debug!("Rendering table");
 
     let mut column_span_buf = String::new();
     let value_one = NonZeroU32::new(1).unwrap();

--- a/src/render/html/element/tabs.rs
+++ b/src/render/html/element/tabs.rs
@@ -23,7 +23,7 @@ use crate::tree::Tab;
 use std::iter;
 
 pub fn render_tabview(ctx: &mut HtmlContext, tabs: &[Tab]) {
-    info!("Rendering tabview (tabs {})", tabs.len());
+    debug!("Rendering tabview (tabs {})", tabs.len());
 
     // Generate IDs for each tab
     let button_ids = generate_ids(ctx.random(), tabs.len());

--- a/src/render/html/element/text.rs
+++ b/src/render/html/element/text.rs
@@ -21,7 +21,7 @@
 use super::prelude::*;
 
 pub fn render_wikitext_raw(ctx: &mut HtmlContext, text: &str) {
-    info!("Escaping raw string '{text}'");
+    debug!("Escaping raw string '{text}'");
 
     ctx.html()
         .span()
@@ -32,7 +32,7 @@ pub fn render_wikitext_raw(ctx: &mut HtmlContext, text: &str) {
 }
 
 pub fn render_email(ctx: &mut HtmlContext, email: &str) {
-    info!("Rendering email address '{email}'");
+    debug!("Rendering email address '{email}'");
 
     // Since our usecase doesn't typically have emails as real,
     // but rather as fictional elements, we're just rendering as text.
@@ -44,7 +44,7 @@ pub fn render_email(ctx: &mut HtmlContext, email: &str) {
 }
 
 pub fn render_code(ctx: &mut HtmlContext, language: Option<&str>, contents: &str) {
-    info!(
+    debug!(
         "Rendering code block (language {})",
         language.unwrap_or("<none>"),
     );

--- a/src/render/html/element/toc.rs
+++ b/src/render/html/element/toc.rs
@@ -26,7 +26,7 @@ pub fn render_table_of_contents(
     align: Option<Alignment>,
     attributes: &AttributeMap,
 ) {
-    info!("Creating table of contents");
+    debug!("Creating table of contents");
     let use_true_ids = ctx.settings().use_true_ids;
 
     let class_value = match align {

--- a/src/render/html/element/user.rs
+++ b/src/render/html/element/user.rs
@@ -28,7 +28,7 @@ pub fn render_user(ctx: &mut HtmlContext, name: &str, show_avatar: bool) {
         .attr(attr!("class" => "wj-user-info"))
         .inner(|ctx| match ctx.handle().get_user_info(name) {
             Some(info) => {
-                debug!(
+                trace!(
                     "Got user information (user id {}, name {})",
                     info.user_id,
                     info.user_name.as_ref(),
@@ -65,7 +65,7 @@ pub fn render_user(ctx: &mut HtmlContext, name: &str, show_avatar: bool) {
                     });
             }
             None => {
-                debug!("No such user found");
+                trace!("No such user found");
 
                 ctx.html()
                     .span()

--- a/src/render/html/element/user.rs
+++ b/src/render/html/element/user.rs
@@ -21,7 +21,7 @@
 use super::prelude::*;
 
 pub fn render_user(ctx: &mut HtmlContext, name: &str, show_avatar: bool) {
-    info!("Rendering user block (name '{name}', show-avatar {show_avatar})");
+    debug!("Rendering user block (name '{name}', show-avatar {show_avatar})");
 
     ctx.html()
         .span()

--- a/src/render/html/mod.rs
+++ b/src/render/html/mod.rs
@@ -57,7 +57,7 @@ impl Render for HtmlRender {
         page_info: &PageInfo,
         settings: &WikitextSettings,
     ) -> HtmlOutput {
-        debug!(
+        info!(
             "Rendering HTML (site {}, page {}, category {})",
             page_info.site.as_ref(),
             page_info.page.as_ref(),

--- a/src/render/html/mod.rs
+++ b/src/render/html/mod.rs
@@ -57,7 +57,7 @@ impl Render for HtmlRender {
         page_info: &PageInfo,
         settings: &WikitextSettings,
     ) -> HtmlOutput {
-        info!(
+        debug!(
             "Rendering HTML (site {}, page {}, category {})",
             page_info.site.as_ref(),
             page_info.page.as_ref(),

--- a/src/render/null.rs
+++ b/src/render/null.rs
@@ -38,6 +38,7 @@ impl Render for NullRender {
         _page_info: &PageInfo,
         _settings: &WikitextSettings,
     ) {
+        info!("Running null renderer");
     }
 }
 

--- a/src/render/text/elements.rs
+++ b/src/render/text/elements.rs
@@ -31,7 +31,7 @@ use super::TextContext;
 use crate::tree::{ContainerType, DefinitionListItem, Element, ListItem, Tab};
 
 pub fn render_elements(ctx: &mut TextContext, elements: &[Element]) {
-    info!("Rendering elements (length {})", elements.len());
+    debug!("Rendering elements (length {})", elements.len());
 
     for element in elements {
         render_element(ctx, element);
@@ -39,7 +39,7 @@ pub fn render_elements(ctx: &mut TextContext, elements: &[Element]) {
 }
 
 pub fn render_element(ctx: &mut TextContext, element: &Element) {
-    info!("Rendering element {}", element.name());
+    debug!("Rendering element {}", element.name());
 
     match element {
         Element::Container(container) => {
@@ -106,7 +106,7 @@ pub fn render_element(ctx: &mut TextContext, element: &Element) {
                 None => format!("{{${name}}}"),
             };
 
-            info!(
+            debug!(
                 "Rendering variable (name '{}', value {})",
                 name.as_ref(),
                 value,
@@ -247,7 +247,7 @@ pub fn render_element(ctx: &mut TextContext, element: &Element) {
             elements,
             ..
         } => {
-            info!(
+            debug!(
                 "Rendering include (variables length {}, elements length {})",
                 variables.len(),
                 elements.len(),

--- a/src/render/text/mod.rs
+++ b/src/render/text/mod.rs
@@ -63,7 +63,7 @@ impl TextRender {
             wikitext_len,
         }: RenderPartial,
     ) -> String {
-        info!(
+        debug!(
             "Rendering text (site {}, page {}, category {})",
             page_info.site.as_ref(),
             page_info.page.as_ref(),

--- a/src/render/text/mod.rs
+++ b/src/render/text/mod.rs
@@ -107,6 +107,16 @@ impl Render for TextRender {
         page_info: &PageInfo,
         settings: &WikitextSettings,
     ) -> String {
+        info!(
+            "Rendering text (site {}, page {}, category {})",
+            page_info.site.as_ref(),
+            page_info.page.as_ref(),
+            match &page_info.category {
+                Some(category) => category.as_ref(),
+                None => "_default",
+            },
+        );
+
         self.render_partial_direct(RenderPartial {
             elements: &tree.elements,
             page_info,

--- a/src/test/ast.rs
+++ b/src/test/ast.rs
@@ -192,7 +192,7 @@ impl Test<'_> {
             return TestResult::Skip;
         }
 
-        info!(
+        debug!(
             "Running syntax tree test case {} on {}",
             &self.name, &self.input,
         );

--- a/src/text.rs
+++ b/src/text.rs
@@ -90,7 +90,7 @@ impl<'t> FullText<'t> {
     }
 
     fn slice_impl(&self, slice_kind: &'static str, start: usize, end: usize) -> &'t str {
-        info!("Extracting {slice_kind} slice ({start}-{end}) from full text");
+        debug!("Extracting {slice_kind} slice ({start}-{end}) from full text");
 
         assert!(
             start <= end,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -49,7 +49,10 @@ impl<'t> From<Tokenization<'t>> for Vec<ExtractedToken<'t>> {
 
 /// Take an input string and produce a list of tokens for consumption by the parser.
 pub fn tokenize(text: &str) -> Tokenization {
-    debug!("Running lexer on text to produce tokens");
+    info!(
+        "Running lexer on text ({} bytes) to produce tokens",
+        text.len(),
+    );
 
     let tokens = Token::extract_all(text);
     let full_text = FullText::new(text);

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -49,7 +49,7 @@ impl<'t> From<Tokenization<'t>> for Vec<ExtractedToken<'t>> {
 
 /// Take an input string and produce a list of tokens for consumption by the parser.
 pub fn tokenize(text: &str) -> Tokenization {
-    info!("Running lexer on text to produce tokens");
+    debug!("Running lexer on text to produce tokens");
 
     let tokens = Token::extract_all(text);
     let full_text = FullText::new(text);

--- a/src/tree/attribute/mod.rs
+++ b/src/tree/attribute/mod.rs
@@ -105,7 +105,7 @@ impl<'t> AttributeMap<'t> {
     pub fn isolate_id(&mut self, settings: &WikitextSettings) {
         if settings.isolate_user_ids {
             if let Some(value) = self.inner.get_mut("id") {
-                debug!("Found 'id' attribute, isolating value");
+                trace!("Found 'id' attribute, isolating value");
                 *value = Cow::Owned(isolate_ids(value));
             }
         }


### PR DESCRIPTION
When we run deepwell, the seeder runs, which floods the screen with tons of log lines for each individual token being processed. While such logging is valuable in debugging ftml, the sheer volume of them in the parent application makes it rather unhelpful (as well as slow, emitting to a file descriptor is not free).

I also bump the version to 1.28.1.