### PR TITLE
[chore] Fix git repository link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = ["parser-implementations"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "1.28.1"
+version = "1.28.2"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ftml"
 description = "Foundation Text Markup Language - a library to render Wikidot text as HTML"
-repository = "https://github.com/scpwiki/wikijump/tree/develop/ftml"
+repository = "https://github.com/scpwiki/ftml"
 readme = "README.md"
 license = "AGPL-3.0-or-later"
 keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]


### PR DESCRIPTION
This wasn't updated since we split the project back out into a separate repository, which leads to incorrect diff links. Bumps patch version as well.