### PR TITLE
[chore] Bump ftml version to 1.29.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = ["parser-implementations"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "1.28.2"
+version = "1.29.0"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2021"
 


### PR DESCRIPTION
The primary name of the `[[include]]` block was changed, so I'm bumping the major version for this release.