### PR TITLE
[WJ-1224] Update code block tree output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = ["parser-implementations"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "1.29.0"
+version = "1.30.0"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2021"
 

--- a/src/parsing/rule/impls/block/blocks/code.rs
+++ b/src/parsing/rule/impls/block/blocks/code.rs
@@ -56,14 +56,17 @@ fn parse_fn<'r, 't>(
     }
 
     let code = parser.get_body_text(&BLOCK_CODE)?;
-    let element = Element::Code {
+    let code_block = CodeBlock {
         contents: cow!(code),
         language,
-    };
-    let added_result = parser.push_code_block(CodeBlock {
-        contents: cow!(code),
         name,
-    });
+    };
+
+    // We need to clone here since the same code block is
+    // conveyed in two places, and some of the fields may
+    // be Cow::Owned.
+    let element = Element::Code(code_block.clone());
+    let added_result = parser.push_code_block(code_block);
     if added_result.is_err() {
         return Err(parser.make_err(ParseErrorKind::CodeNonUniqueName));
     }

--- a/src/render/html/element/mod.rs
+++ b/src/render/html/element/mod.rs
@@ -71,7 +71,7 @@ use self::toc::render_table_of_contents;
 use self::user::render_user;
 use super::attributes::AddedAttributes;
 use super::HtmlContext;
-use crate::tree::Element;
+use crate::tree::{CodeBlock, Element};
 use ref_map::*;
 
 pub fn render_elements(ctx: &mut HtmlContext, elements: &[Element]) {
@@ -182,9 +182,11 @@ pub fn render_element(ctx: &mut HtmlContext, element: &Element) {
             hover,
         } => render_date(ctx, *value, ref_cow!(format), *hover),
         Element::Color { color, elements } => render_color(ctx, color, elements),
-        Element::Code { contents, language } => {
-            render_code(ctx, ref_cow!(language), contents)
-        }
+        Element::Code(CodeBlock {
+            contents,
+            language,
+            name: _,
+        }) => render_code(ctx, ref_cow!(language), contents),
         Element::Math { name, latex_source } => {
             render_math_block(ctx, ref_cow!(name), latex_source)
         }

--- a/src/render/text/elements.rs
+++ b/src/render/text/elements.rs
@@ -28,7 +28,7 @@
 //! Any formatting present must be directly justifiable.
 
 use super::TextContext;
-use crate::tree::{ContainerType, DefinitionListItem, Element, ListItem, Tab};
+use crate::tree::{CodeBlock, ContainerType, DefinitionListItem, Element, ListItem, Tab};
 
 pub fn render_elements(ctx: &mut TextContext, elements: &[Element]) {
     debug!("Rendering elements (length {})", elements.len());
@@ -227,7 +227,7 @@ pub fn render_element(ctx: &mut TextContext, element: &Element) {
             };
         }
         Element::Color { elements, .. } => render_elements(ctx, elements),
-        Element::Code { contents, .. } => {
+        Element::Code(CodeBlock { contents, .. }) => {
             ctx.add_newline();
             ctx.push_str(contents);
             ctx.add_newline();

--- a/src/test/prop.rs
+++ b/src/test/prop.rs
@@ -22,11 +22,11 @@ use crate::data::{PageInfo, PageRef};
 use crate::layout::Layout;
 use crate::render::{html::HtmlRender, text::TextRender, Render};
 use crate::settings::{WikitextMode, WikitextSettings};
-use crate::tree::attribute::SAFE_ATTRIBUTES;
 use crate::tree::{
-    Alignment, AnchorTarget, AttributeMap, BibliographyList, ClearFloat, Container,
-    ContainerType, Element, FloatAlignment, Heading, HeadingLevel, ImageSource,
-    LinkLabel, LinkLocation, LinkType, ListItem, ListType, Module, SyntaxTree,
+    attribute::SAFE_ATTRIBUTES, Alignment, AnchorTarget, AttributeMap, BibliographyList,
+    ClearFloat, CodeBlock, Container, ContainerType, Element, FloatAlignment, Heading,
+    HeadingLevel, ImageSource, LinkLabel, LinkLocation, LinkType, ListItem, ListType,
+    Module, SyntaxTree,
 };
 use once_cell::sync::Lazy;
 use proptest::option;
@@ -243,8 +243,15 @@ where
 }
 
 fn arb_code() -> impl Strategy<Value = Element<'static>> {
-    (cow!(".*"), arb_optional_str())
-        .prop_map(|(contents, language)| Element::Code { contents, language })
+    (cow!(".*"), arb_optional_str(), arb_optional_str()).prop_map(
+        |(contents, language, name)| {
+            Element::Code(CodeBlock {
+                contents,
+                language,
+                name,
+            })
+        },
+    )
 }
 
 fn arb_checkbox() -> impl Strategy<Value = Element<'static>> {

--- a/src/tree/code.rs
+++ b/src/tree/code.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
 pub struct CodeBlock<'t> {
     pub contents: Cow<'t, str>,
+    pub language: Option<Cow<'t, str>>,
     pub name: Option<Cow<'t, str>>,
 }
 
@@ -33,6 +34,7 @@ impl CodeBlock<'_> {
     pub fn to_owned(&self) -> CodeBlock<'static> {
         CodeBlock {
             contents: string_to_owned(&self.contents),
+            language: option_string_to_owned(&self.language),
             name: option_string_to_owned(&self.name),
         }
     }

--- a/src/tree/element/object.rs
+++ b/src/tree/element/object.rs
@@ -21,7 +21,7 @@
 use crate::data::PageRef;
 use crate::tree::clone::*;
 use crate::tree::{
-    Alignment, AnchorTarget, AttributeMap, ClearFloat, Container, DateItem,
+    Alignment, AnchorTarget, AttributeMap, ClearFloat, CodeBlock, Container, DateItem,
     DefinitionListItem, Embed, FloatAlignment, ImageSource, LinkLabel, LinkLocation,
     LinkType, ListItem, ListType, Module, PartialElement, Tab, Table, VariableMap,
 };
@@ -229,10 +229,7 @@ pub enum Element<'t> {
     },
 
     /// Element containing a code block.
-    Code {
-        contents: Cow<'t, str>,
-        language: Option<Cow<'t, str>>,
-    },
+    Code(CodeBlock<'t>),
 
     /// Element containing a named math equation.
     #[serde(rename_all = "kebab-case")]
@@ -546,10 +543,7 @@ impl Element<'_> {
                 color: string_to_owned(color),
                 elements: elements_to_owned(elements),
             },
-            Element::Code { contents, language } => Element::Code {
-                contents: string_to_owned(contents),
-                language: option_string_to_owned(language),
-            },
+            Element::Code(code_block) => Element::Code(code_block.to_owned()),
             Element::Math { name, latex_source } => Element::Math {
                 name: option_string_to_owned(name),
                 latex_source: string_to_owned(latex_source),

--- a/test/code-block.json
+++ b/test/code-block.json
@@ -6,7 +6,8 @@
                 "element": "code",
                 "data": {
                     "contents": "[[div]]\ntest\n[[/div]]",
-                    "language": null
+                    "language": null,
+                    "name": null
                 }
             },
             {
@@ -22,6 +23,7 @@
         "code-blocks": [
             {
                 "contents": "[[div]]\ntest\n[[/div]]",
+                "language": null,
                 "name": null
             }
         ],

--- a/test/code-empty.json
+++ b/test/code-empty.json
@@ -6,7 +6,8 @@
                 "element": "code",
                 "data": {
                     "contents": "",
-                    "language": null
+                    "language": null,
+                    "name": null
                 }
             },
             {
@@ -22,6 +23,7 @@
         "code-blocks": [
             {
                 "contents": "",
+                "language": null,
                 "name": null
             }
         ],

--- a/test/code-inline-empty.json
+++ b/test/code-inline-empty.json
@@ -6,7 +6,8 @@
                 "element": "code",
                 "data": {
                     "contents": "",
-                    "language": null
+                    "language": null,
+                    "name": null
                 }
             },
             {
@@ -22,6 +23,7 @@
         "code-blocks": [
             {
                 "contents": "",
+                "language": null,
                 "name": null
             }
         ],

--- a/test/code-inline.json
+++ b/test/code-inline.json
@@ -6,7 +6,8 @@
                 "element": "code",
                 "data": {
                     "contents": "text here",
-                    "language": null
+                    "language": null,
+                    "name": null
                 }
             },
             {
@@ -22,7 +23,8 @@
         "code-blocks": [
             {
                 "contents": "text here",
-                "name": null
+                "name": null,
+                "language": null
             }
         ],
         "table-of-contents": [

--- a/test/code-language-empty.json
+++ b/test/code-language-empty.json
@@ -6,7 +6,8 @@
                 "element": "code",
                 "data": {
                     "contents": "",
-                    "language": "css"
+                    "language": "css",
+                    "name": null
                 }
             },
             {
@@ -22,6 +23,7 @@
         "code-blocks": [
             {
                 "contents": "",
+                "language": "css",
                 "name": null
             }
         ],

--- a/test/code-language-spaces.json
+++ b/test/code-language-spaces.json
@@ -6,7 +6,8 @@
                 "element": "code",
                 "data": {
                     "contents": "apple banana",
-                    "language": "css"
+                    "language": "css",
+                    "name": null
                 }
             },
             {
@@ -22,6 +23,7 @@
         "code-blocks": [
             {
                 "contents": "apple banana",
+                "language": "css",
                 "name": null
             }
         ],

--- a/test/code-language.json
+++ b/test/code-language.json
@@ -6,7 +6,8 @@
                 "element": "code",
                 "data": {
                     "contents": "apple banana",
-                    "language": "css"
+                    "language": "css",
+                    "name": null
                 }
             },
             {
@@ -22,6 +23,7 @@
         "code-blocks": [
             {
                 "contents": "apple banana",
+                "language": "css",
                 "name": null
             }
         ],

--- a/test/code-multiline.json
+++ b/test/code-multiline.json
@@ -6,7 +6,8 @@
                 "element": "code",
                 "data": {
                     "contents": "multiple\n**lines**\nof\ncode",
-                    "language": null
+                    "language": null,
+                    "name": null
                 }
             },
             {
@@ -22,6 +23,7 @@
         "code-blocks": [
             {
                 "contents": "multiple\n**lines**\nof\ncode",
+                "language": null,
                 "name": null
             }
         ],

--- a/test/code-name.json
+++ b/test/code-name.json
@@ -6,21 +6,24 @@
                 "element": "code",
                 "data": {
                     "contents": "FOO",
-                    "language": null
+                    "language": null,
+                    "name": "a"
                 }
             },
             {
                 "element": "code",
                 "data": {
                     "contents": "BAR",
-                    "language": null
+                    "language": null,
+                    "name": null
                 }
             },
             {
                 "element": "code",
                 "data": {
                     "contents": "BAZ",
-                    "language": "java"
+                    "language": "java",
+                    "name": "b"
                 }
             },
             {
@@ -36,14 +39,17 @@
         "code-blocks": [
             {
                 "contents": "FOO",
+                "language": null,
                 "name": "a"
             },
             {
                 "contents": "BAR",
+                "language": null,
                 "name": null
             },
             {
                 "contents": "BAZ",
+                "language": "java",
                 "name": "b"
             }
         ],

--- a/test/code-spaces.json
+++ b/test/code-spaces.json
@@ -6,7 +6,8 @@
                 "element": "code",
                 "data": {
                     "contents": "text here",
-                    "language": null
+                    "language": null,
+                    "name": null
                 }
             },
             {
@@ -22,6 +23,7 @@
         "code-blocks": [
             {
                 "contents": "text here",
+                "language": null,
                 "name": null
             }
         ],

--- a/test/code-uppercase.json
+++ b/test/code-uppercase.json
@@ -6,7 +6,8 @@
                 "element": "code",
                 "data": {
                     "contents": "text here",
-                    "language": null
+                    "language": null,
+                    "name": null
                 }
             },
             {
@@ -22,6 +23,7 @@
         "code-blocks": [
             {
                 "contents": "text here",
+                "language": null,
                 "name": null
             }
         ],


### PR DESCRIPTION
Previously, the ancillar code block fields `name` and `language` were split in two different places. This changes the way code blocks are done so that there is one struct, `CodeBlock`, which is exposed both in the tree structure and in the list of all code blocks in the overall tree output.

I also bump the version to note this change. (Note #41 should be merged first).