### PR TITLE
[WJ-1224] Remove parser error for duplicate code names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = ["parser-implementations"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "1.30.0"
+version = "1.31.0"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2021"
 

--- a/src/parsing/error.rs
+++ b/src/parsing/error.rs
@@ -169,9 +169,6 @@ pub enum ParseErrorKind {
     /// Bibliography contains an element other than a definition list.
     BibliographyContainsNonDefinitionList,
 
-    /// Code block has a name which is not unique.
-    CodeNonUniqueName,
-
     /// There is no rule for the block name specified.
     NoSuchBlock,
 

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -262,27 +262,12 @@ impl<'r, 't> Parser<'r, 't> {
         self.html_blocks.borrow_mut().push(new_block);
     }
 
-    pub fn push_code_block(
-        &mut self,
-        new_block: CodeBlock<'t>,
-    ) -> Result<(), NonUniqueNameError> {
-        // Check name (if specified) is unique
-        {
-            let guard = self.code_blocks.borrow();
-            if let Some(ref new_name) = new_block.name {
-                for block in &*guard {
-                    if let Some(ref name) = block.name {
-                        if name == new_name {
-                            return Err(NonUniqueNameError);
-                        }
-                    }
-                }
-            }
-        }
-
-        // Add block
+    pub fn push_code_block(&mut self, new_block: CodeBlock<'t>) {
+        // NOTE: We do not check if code block names are unique.
+        //       It is the responsibility of downstream callers
+        //       (such as deepwell) to handle these when doing
+        //       hosted text block processing.
         self.code_blocks.borrow_mut().push(new_block);
-        Ok(())
     }
 
     // Bibliography
@@ -570,9 +555,6 @@ impl<'r, 't> Parser<'r, 't> {
         ParseError::new(kind, self.rule, self.current)
     }
 }
-
-#[derive(Debug)]
-pub struct NonUniqueNameError;
 
 #[inline]
 fn make_shared_vec<T>() -> Rc<RefCell<Vec<T>>> {

--- a/src/parsing/rule/impls/block/blocks/code.rs
+++ b/src/parsing/rule/impls/block/blocks/code.rs
@@ -66,10 +66,6 @@ fn parse_fn<'r, 't>(
     // conveyed in two places, and some of the fields may
     // be Cow::Owned.
     let element = Element::Code(code_block.clone());
-    let added_result = parser.push_code_block(code_block);
-    if added_result.is_err() {
-        return Err(parser.make_err(ParseErrorKind::CodeNonUniqueName));
-    }
-
+    parser.push_code_block(code_block);
     ok!(element)
 }

--- a/src/parsing/rule/impls/block/blocks/html.rs
+++ b/src/parsing/rule/impls/block/blocks/html.rs
@@ -47,6 +47,5 @@ fn parse_fn<'r, 't>(
         contents: cow!(html),
     };
     parser.push_html_block(cow!(html));
-
     ok!(element)
 }


### PR DESCRIPTION
Blocker for https://github.com/scpwiki/wikijump/pull/2354. While developing hosted text blocks in Wikijump, I noticed that I had added a parser error for this case, which means that the revision creation actually _succeeds_ (since parser errors, previously called warnings, do not fail revision commit).

So now the responsibility for data uniqueness is on the consumer, who can do with code block names as they wish. In the case of deepwell, it can fail the revision or remove the duplicate name, or whatever it decides is best.

With this change, this PR also bumps the version number to v1.31.0.