### PR TITLE
Replace all once_cell uses with LazyLock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ entities = "1"
 latex2mathml = { version = "0.2", optional = true }
 log = "0.4"
 maplit = "1"
-once_cell = "1.17.1"
 parcel_css = { version = "1.0.0-alpha.32", optional = true }
 parcel_selectors = "=0.24.7"  # this is *not* a required dependency,
                               # but we are pinning it since 0.24.8 does

--- a/src/includes/mod.rs
+++ b/src/includes/mod.rs
@@ -39,10 +39,10 @@ use self::parse::parse_include_block;
 use crate::data::PageRef;
 use crate::settings::WikitextSettings;
 use crate::tree::VariableMap;
-use once_cell::sync::Lazy;
 use regex::{Regex, RegexBuilder};
+use std::sync::LazyLock;
 
-static INCLUDE_REGEX: Lazy<Regex> = Lazy::new(|| {
+static INCLUDE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     RegexBuilder::new(r"^\[\[\s*include\s+")
         .case_insensitive(true)
         .multi_line(true)
@@ -50,8 +50,8 @@ static INCLUDE_REGEX: Lazy<Regex> = Lazy::new(|| {
         .build()
         .unwrap()
 });
-static VARIABLE_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"\{\$(?P<name>[a-zA-Z0-9_\-]+)\}").unwrap());
+static VARIABLE_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\{\$(?P<name>[a-zA-Z0-9_\-]+)\}").unwrap());
 
 /// Replaces the include blocks in a string with the content of the pages referenced by those
 /// blocks.

--- a/src/info.rs
+++ b/src/info.rs
@@ -31,9 +31,9 @@ pub use self::build::{
     RUSTC_VERSION, TARGET,
 };
 
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
-static VERSION_INFO: Lazy<String> = Lazy::new(|| {
+static VERSION_INFO: LazyLock<String> = LazyLock::new(|| {
     let mut version = format!("v{PKG_VERSION}");
 
     if let Some(commit_hash) = *GIT_COMMIT_HASH_SHORT {
@@ -42,10 +42,13 @@ static VERSION_INFO: Lazy<String> = Lazy::new(|| {
 
     version
 });
+
 /// The package name and version info.
-pub static VERSION: Lazy<String> = Lazy::new(|| format!("{PKG_NAME} {}", *VERSION_INFO));
+pub static VERSION: LazyLock<String> =
+    LazyLock::new(|| format!("{PKG_NAME} {}", *VERSION_INFO));
+
 /// The full version info, including build information.
-pub static FULL_VERSION: Lazy<String> = Lazy::new(|| {
+pub static FULL_VERSION: LazyLock<String> = LazyLock::new(|| {
     let mut version = format!("{}\n\nCompiled:\n", *VERSION_INFO);
 
     str_writeln!(&mut version, "* across {NUM_JOBS} threads");
@@ -56,11 +59,12 @@ pub static FULL_VERSION: Lazy<String> = Lazy::new(|| {
     version
 });
 /// The package name and full version info, including build information.
-pub static FULL_VERSION_WITH_NAME: Lazy<String> =
-    Lazy::new(|| format!("{PKG_NAME} {}", *FULL_VERSION));
+pub static FULL_VERSION_WITH_NAME: LazyLock<String> =
+    LazyLock::new(|| format!("{PKG_NAME} {}", *FULL_VERSION));
+
 // The last 8 characters of the commit hash for this version.
-pub static GIT_COMMIT_HASH_SHORT: Lazy<Option<&'static str>> =
-    Lazy::new(|| GIT_COMMIT_HASH.map(|s| &s[..8]));
+pub static GIT_COMMIT_HASH_SHORT: LazyLock<Option<&'static str>> =
+    LazyLock::new(|| GIT_COMMIT_HASH.map(|s| &s[..8]));
 
 #[test]
 fn info() {

--- a/src/parsing/rule/impls/block/blocks/char.rs
+++ b/src/parsing/rule/impls/block/blocks/char.rs
@@ -20,23 +20,24 @@
 
 use super::prelude::*;
 use entities::ENTITIES;
-use once_cell::sync::Lazy;
 use std::borrow::Cow;
 use std::char;
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
-static ENTITY_MAPPING: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
-    let mut mapping = HashMap::new();
+static ENTITY_MAPPING: LazyLock<HashMap<&'static str, &'static str>> =
+    LazyLock::new(|| {
+        let mut mapping = HashMap::new();
 
-    for entity in &ENTITIES {
-        let key = strip_entity(entity.entity);
-        let value = entity.characters;
+        for entity in &ENTITIES {
+            let key = strip_entity(entity.entity);
+            let value = entity.characters;
 
-        mapping.insert(key, value);
-    }
+            mapping.insert(key, value);
+        }
 
-    mapping
-});
+        mapping
+    });
 
 pub const BLOCK_CHAR: BlockRule = BlockRule {
     name: "block-char",

--- a/src/parsing/rule/impls/block/blocks/date.rs
+++ b/src/parsing/rule/impls/block/blocks/date.rs
@@ -20,8 +20,8 @@
 
 use super::prelude::*;
 use crate::tree::DateItem;
-use once_cell::sync::Lazy;
 use regex::Regex;
+use std::sync::LazyLock;
 use time::format_description::well_known::{Iso8601, Rfc2822, Rfc3339};
 use time::{Date, OffsetDateTime, PrimitiveDateTime, UtcOffset};
 
@@ -147,8 +147,8 @@ fn parse_date(value: &str) -> Result<DateItem, DateParseError> {
 
 /// Parse the timezone based on the specifier string.
 fn parse_timezone(value: &str) -> Result<UtcOffset, DateParseError> {
-    static TIMEZONE_REGEX: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"^(\+|-)?([0-9]{1,2}):?([0-9]{2})?$").unwrap());
+    static TIMEZONE_REGEX: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^(\+|-)?([0-9]{1,2}):?([0-9]{2})?$").unwrap());
 
     debug!("Parsing possible timezone value '{value}'");
 

--- a/src/parsing/rule/impls/block/blocks/module/mapping.rs
+++ b/src/parsing/rule/impls/block/blocks/module/mapping.rs
@@ -19,8 +19,8 @@
  */
 
 use super::{modules::*, ModuleRule};
-use once_cell::sync::Lazy;
 use std::collections::HashMap;
+use std::sync::LazyLock;
 use unicase::UniCase;
 
 pub const MODULE_RULES: [ModuleRule; 6] = [
@@ -34,8 +34,8 @@ pub const MODULE_RULES: [ModuleRule; 6] = [
 
 pub type ModuleRuleMap = HashMap<UniCase<&'static str>, &'static ModuleRule>;
 
-pub static MODULE_RULE_MAP: Lazy<ModuleRuleMap> =
-    Lazy::new(|| build_module_rule_map(&MODULE_RULES));
+pub static MODULE_RULE_MAP: LazyLock<ModuleRuleMap> =
+    LazyLock::new(|| build_module_rule_map(&MODULE_RULES));
 
 #[inline]
 pub fn get_module_rule_with_name(name: &str) -> Option<&'static ModuleRule> {

--- a/src/parsing/rule/impls/block/mapping.rs
+++ b/src/parsing/rule/impls/block/mapping.rs
@@ -19,8 +19,8 @@
  */
 
 use super::{blocks::*, BlockRule};
-use once_cell::sync::Lazy;
 use std::collections::HashMap;
+use std::sync::LazyLock;
 use unicase::UniCase;
 
 pub const BLOCK_RULES: [BlockRule; 60] = [
@@ -88,8 +88,8 @@ pub const BLOCK_RULES: [BlockRule; 60] = [
 
 pub type BlockRuleMap = HashMap<UniCase<&'static str>, &'static BlockRule>;
 
-pub static BLOCK_RULE_MAP: Lazy<BlockRuleMap> =
-    Lazy::new(|| build_block_rule_map(&BLOCK_RULES));
+pub static BLOCK_RULE_MAP: LazyLock<BlockRuleMap> =
+    LazyLock::new(|| build_block_rule_map(&BLOCK_RULES));
 
 #[inline]
 pub fn get_block_rule_with_name(name: &str) -> Option<&'static BlockRule> {

--- a/src/parsing/rule/impls/block/parser.rs
+++ b/src/parsing/rule/impls/block/parser.rs
@@ -28,10 +28,11 @@ use crate::parsing::{
     ParseResult, Parser, Token,
 };
 use crate::tree::Element;
-use once_cell::sync::Lazy;
 use regex::Regex;
+use std::sync::LazyLock;
 
-static ARGUMENT_KEY: Lazy<Regex> = Lazy::new(|| Regex::new(r"[A-Za-z0-9_\-]+").unwrap());
+static ARGUMENT_KEY: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"[A-Za-z0-9_\-]+").unwrap());
 
 impl<'r, 't> Parser<'r, 't>
 where

--- a/src/parsing/rule/impls/color.rs
+++ b/src/parsing/rule/impls/color.rs
@@ -19,12 +19,12 @@
  */
 
 use super::prelude::*;
-use once_cell::sync::Lazy;
 use regex::Regex;
 use std::borrow::Cow;
+use std::sync::LazyLock;
 
-static HEX_COLOR: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$").unwrap());
+static HEX_COLOR: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$").unwrap());
 
 pub const RULE_COLOR: Rule = Rule {
     name: "color",

--- a/src/parsing/rule/impls/variable.rs
+++ b/src/parsing/rule/impls/variable.rs
@@ -19,10 +19,11 @@
  */
 
 use super::prelude::*;
-use once_cell::sync::Lazy;
 use regex::Regex;
+use std::sync::LazyLock;
 
-static VARIABLE_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"\{\$(.+)\}").unwrap());
+static VARIABLE_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\{\$(.+)\}").unwrap());
 
 pub const RULE_VARIABLE: Rule = Rule {
     name: "variable",

--- a/src/parsing/rule/mapping.rs
+++ b/src/parsing/rule/mapping.rs
@@ -21,7 +21,7 @@
 use super::{impls::*, Rule};
 use crate::parsing::token::{ExtractedToken, Token};
 use enum_map::EnumMap;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
 /// Mapping of all tokens to the rules they possibly correspond with.
 ///
@@ -31,7 +31,7 @@ use once_cell::sync::Lazy;
 /// An empty list means that this is a special token that shouldn't be used
 /// in this manner. It will of course fall back to interpreting this token
 /// as text, but will also produce an error for the user.
-pub static RULE_MAP: Lazy<EnumMap<Token, Vec<Rule>>> = Lazy::new(|| {
+pub static RULE_MAP: LazyLock<EnumMap<Token, Vec<Rule>>> = LazyLock::new(|| {
     enum_map! {
         // Symbols
         Token::LeftBracket => vec![RULE_LINK_SINGLE, RULE_TEXT],

--- a/src/preproc/typography.rs
+++ b/src/preproc/typography.rs
@@ -33,12 +33,12 @@
 //! the `--` in `[!--` and `--]` into em dashes.
 
 use super::Replacer;
-use once_cell::sync::Lazy;
 use regex::Regex;
+use std::sync::LazyLock;
 
 // ‘ - LEFT SINGLE QUOTATION MARK
 // ’ - RIGHT SINGLE QUOTATION MARK
-static SINGLE_QUOTES: Lazy<Replacer> = Lazy::new(|| Replacer::RegexSurround {
+static SINGLE_QUOTES: LazyLock<Replacer> = LazyLock::new(|| Replacer::RegexSurround {
     regex: Regex::new(r"`(.*?)'").unwrap(),
     begin: "\u{2018}",
     end: "\u{2019}",
@@ -46,24 +46,26 @@ static SINGLE_QUOTES: Lazy<Replacer> = Lazy::new(|| Replacer::RegexSurround {
 
 // “ - LEFT DOUBLE QUOTATION MARK
 // ” - RIGHT DOUBLE QUOTATION MARK
-static DOUBLE_QUOTES: Lazy<Replacer> = Lazy::new(|| Replacer::RegexSurround {
+static DOUBLE_QUOTES: LazyLock<Replacer> = LazyLock::new(|| Replacer::RegexSurround {
     regex: Regex::new(r"``(.*?)''").unwrap(),
     begin: "\u{201c}",
     end: "\u{201d}",
 });
 
 // „ - DOUBLE LOW-9 QUOTATION MARK
-static LOW_DOUBLE_QUOTES: Lazy<Replacer> = Lazy::new(|| Replacer::RegexSurround {
-    regex: Regex::new(r",,(.*?)''").unwrap(),
-    begin: "\u{201e}",
-    end: "\u{201d}",
-});
+static LOW_DOUBLE_QUOTES: LazyLock<Replacer> =
+    LazyLock::new(|| Replacer::RegexSurround {
+        regex: Regex::new(r",,(.*?)''").unwrap(),
+        begin: "\u{201e}",
+        end: "\u{201d}",
+    });
 
 // … - HORIZONTAL ELLIPSIS
-static HORIZONTAL_ELLIPSIS: Lazy<Replacer> = Lazy::new(|| Replacer::RegexReplace {
-    regex: Regex::new(r"(?:^|[^\.])(?<repl>(\.\.|\. \. )\.)(?:[^\.]|$)").unwrap(),
-    replacement: "\u{2026}",
-});
+static HORIZONTAL_ELLIPSIS: LazyLock<Replacer> =
+    LazyLock::new(|| Replacer::RegexReplace {
+        regex: Regex::new(r"(?:^|[^\.])(?<repl>(\.\.|\. \. )\.)(?:[^\.]|$)").unwrap(),
+        replacement: "\u{2026}",
+    });
 
 /// Performs all typographic substitutions in-place in the given text
 pub fn substitute(text: &mut String) {

--- a/src/preproc/whitespace.rs
+++ b/src/preproc/whitespace.rs
@@ -28,43 +28,44 @@
 //! * Compress groups of 3+ newlines into 2 newlines
 
 use super::Replacer;
-use once_cell::sync::Lazy;
 use regex::{Regex, RegexBuilder};
+use std::sync::LazyLock;
 
-static LEADING_NONSTANDARD_WHITESPACE: Lazy<Regex> = Lazy::new(|| {
+static LEADING_NONSTANDARD_WHITESPACE: LazyLock<Regex> = LazyLock::new(|| {
     RegexBuilder::new("^[\u{00a0}\u{2007}]+")
         .multi_line(true)
         .build()
         .unwrap()
 });
-static WHITESPACE_ONLY_LINE: Lazy<Replacer> = Lazy::new(|| Replacer::RegexReplace {
-    regex: RegexBuilder::new(r"^\s+$")
-        .multi_line(true)
-        .build()
-        .unwrap(),
-    replacement: "",
-});
-static LEADING_NEWLINES: Lazy<Replacer> = Lazy::new(|| Replacer::RegexReplace {
+static WHITESPACE_ONLY_LINE: LazyLock<Replacer> =
+    LazyLock::new(|| Replacer::RegexReplace {
+        regex: RegexBuilder::new(r"^\s+$")
+            .multi_line(true)
+            .build()
+            .unwrap(),
+        replacement: "",
+    });
+static LEADING_NEWLINES: LazyLock<Replacer> = LazyLock::new(|| Replacer::RegexReplace {
     regex: Regex::new(r"^\n+").unwrap(),
     replacement: "",
 });
-static TRAILING_NEWLINES: Lazy<Replacer> = Lazy::new(|| Replacer::RegexReplace {
+static TRAILING_NEWLINES: LazyLock<Replacer> = LazyLock::new(|| Replacer::RegexReplace {
     regex: Regex::new(r"\n+$").unwrap(),
     replacement: "",
 });
-static DOS_MAC_NEWLINES: Lazy<Replacer> = Lazy::new(|| Replacer::RegexReplace {
+static DOS_MAC_NEWLINES: LazyLock<Replacer> = LazyLock::new(|| Replacer::RegexReplace {
     regex: Regex::new(r"\r\n?").unwrap(),
     replacement: "\n",
 });
-static CONCAT_LINES: Lazy<Replacer> = Lazy::new(|| Replacer::RegexReplace {
+static CONCAT_LINES: LazyLock<Replacer> = LazyLock::new(|| Replacer::RegexReplace {
     regex: Regex::new(r"\\\n").unwrap(),
     replacement: "",
 });
-static TABS: Lazy<Replacer> = Lazy::new(|| Replacer::RegexReplace {
+static TABS: LazyLock<Replacer> = LazyLock::new(|| Replacer::RegexReplace {
     regex: Regex::new("\t").unwrap(),
     replacement: "    ",
 });
-static NULL_SPACE: Lazy<Replacer> = Lazy::new(|| Replacer::RegexReplace {
+static NULL_SPACE: LazyLock<Replacer> = LazyLock::new(|| Replacer::RegexReplace {
     regex: Regex::new("\0").unwrap(),
     replacement: " ",
 });

--- a/src/settings/interwiki.rs
+++ b/src/settings/interwiki.rs
@@ -18,14 +18,15 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use once_cell::sync::Lazy;
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
 /// An [`InterwikiSettings`] instance that has no prefixes.
-pub static EMPTY_INTERWIKI: Lazy<InterwikiSettings> = Lazy::new(|| InterwikiSettings {
-    prefixes: hashmap! {},
-});
+pub static EMPTY_INTERWIKI: LazyLock<InterwikiSettings> =
+    LazyLock::new(|| InterwikiSettings {
+        prefixes: hashmap! {},
+    });
 
 #[allow(rustdoc::bare_urls)]
 /// An [`InterwikiSettings`] instance that has the default prefixes.
@@ -39,18 +40,19 @@ pub static EMPTY_INTERWIKI: Lazy<InterwikiSettings> = Lazy::new(|| InterwikiSett
 /// - `ddg:path` => `https://duckduckgo.com/?q=path`
 /// - `dictionary:path` => `https://dictionary.com/browse/path`
 /// - `thesaurus:path` => `https://thesaurus.com/browse/path`
-pub static DEFAULT_INTERWIKI: Lazy<InterwikiSettings> = Lazy::new(|| InterwikiSettings {
-    prefixes: hashmap! {
-        cow!("wikipedia") => cow!("https://wikipedia.org/wiki/$$"),
-        cow!("wp") => cow!("https://wikipedia.org/wiki/$$"),
-        cow!("commons") => cow!("https://commons.wikimedia.org/wiki/$$"),
-        cow!("google") => cow!("https://google.com/search?q=$$"),
-        cow!("duckduckgo") => cow!("https://duckduckgo.com/?q=$$"),
-        cow!("ddg") => cow!("https://duckduckgo.com/?q=$$"),
-        cow!("dictionary") => cow!("https://dictionary.com/browse/$$"),
-        cow!("thesaurus") => cow!("https://thesaurus.com/browse/$$"),
-    },
-});
+pub static DEFAULT_INTERWIKI: LazyLock<InterwikiSettings> =
+    LazyLock::new(|| InterwikiSettings {
+        prefixes: hashmap! {
+            cow!("wikipedia") => cow!("https://wikipedia.org/wiki/$$"),
+            cow!("wp") => cow!("https://wikipedia.org/wiki/$$"),
+            cow!("commons") => cow!("https://commons.wikimedia.org/wiki/$$"),
+            cow!("google") => cow!("https://google.com/search?q=$$"),
+            cow!("duckduckgo") => cow!("https://duckduckgo.com/?q=$$"),
+            cow!("ddg") => cow!("https://duckduckgo.com/?q=$$"),
+            cow!("dictionary") => cow!("https://dictionary.com/browse/$$"),
+            cow!("thesaurus") => cow!("https://thesaurus.com/browse/$$"),
+        },
+    });
 
 /// Settings that determine how to turn [`interwiki links`](http://org.wikidot.com/doc:wiki-syntax#toc21)
 /// into full URLs.

--- a/src/test/ast/mod.rs
+++ b/src/test/ast/mod.rs
@@ -26,10 +26,10 @@ mod runner;
 
 use crate::parsing::ParseError;
 use crate::tree::SyntaxTree;
-use once_cell::sync::Lazy;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::process;
+use std::sync::LazyLock;
 
 // Debug settings
 
@@ -56,7 +56,7 @@ const UPDATE_TESTS: bool = false;
 
 /// The directory where all test files are located.
 /// This is the directory `test` under the repository root.
-static TEST_DIRECTORY: Lazy<PathBuf> = Lazy::new(|| {
+static TEST_DIRECTORY: LazyLock<PathBuf> = LazyLock::new(|| {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("test");
     path

--- a/src/test/prop.rs
+++ b/src/test/prop.rs
@@ -28,16 +28,16 @@ use crate::tree::{
     HeadingLevel, ImageSource, LinkLabel, LinkLocation, LinkType, ListItem, ListType,
     Module, SyntaxTree,
 };
-use once_cell::sync::Lazy;
 use proptest::option;
 use proptest::prelude::*;
 use std::borrow::Cow;
 use std::num::NonZeroU32;
+use std::sync::LazyLock;
 
 // Constants
 
-static SAFE_ATTRIBUTES_VEC: Lazy<Vec<&'static str>> =
-    Lazy::new(|| SAFE_ATTRIBUTES.iter().map(|s| s.as_ref()).collect());
+static SAFE_ATTRIBUTES_VEC: LazyLock<Vec<&'static str>> =
+    LazyLock::new(|| SAFE_ATTRIBUTES.iter().map(|s| s.as_ref()).collect());
 
 const SIMPLE_EMAIL_REGEX: &str = r"\w+([-+.']\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*";
 const SIMPLE_URL_REGEX: &str = r"https?://([-.]\w)+";

--- a/src/tree/align.rs
+++ b/src/tree/align.rs
@@ -73,10 +73,10 @@ pub struct FloatAlignment {
 
 impl FloatAlignment {
     pub fn parse(name: &str) -> Option<Self> {
-        use once_cell::sync::Lazy;
+        use std::sync::LazyLock;
 
-        static IMAGE_ALIGNMENT_REGEX: Lazy<Regex> =
-            Lazy::new(|| Regex::new(r"^[fF]?([<=>])").unwrap());
+        static IMAGE_ALIGNMENT_REGEX: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^[fF]?([<=>])").unwrap());
 
         IMAGE_ALIGNMENT_REGEX
             .find(name)

--- a/src/tree/attribute/safe.rs
+++ b/src/tree/attribute/safe.rs
@@ -18,9 +18,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use once_cell::sync::Lazy;
 use regex::Regex;
 use std::collections::HashSet;
+use std::sync::LazyLock;
 use unicase::UniCase;
 
 macro_rules! hashset_unicase {
@@ -40,93 +40,94 @@ macro_rules! hashset_unicase {
 /// List of safe attributes. All others will be filtered out.
 ///
 /// See <https://scuttle.atlassian.net/wiki/spaces/WD/pages/1030782977/Allowed+Attributes+in+Wikitext>
-pub static SAFE_ATTRIBUTES: Lazy<HashSet<UniCase<&'static str>>> = Lazy::new(|| {
-    hashset_unicase![
-        "accept",
-        "align",
-        "alt",
-        "autocapitalize",
-        "autoplay",
-        "background",
-        "bgcolor",
-        "border",
-        "buffered",
-        "checked",
-        "cite",
-        "class",
-        "cols",
-        "colspan",
-        "contenteditable",
-        "controls",
-        "coords",
-        "datetime",
-        "decoding",
-        "default",
-        "dir",
-        "dirname",
-        "disabled",
-        "download",
-        "draggable",
-        "for",
-        "form",
-        "headers",
-        "height",
-        "hidden",
-        "high",
-        "href",
-        "hreflang",
-        "id",
-        "inputmode",
-        "ismap",
-        "itemprop",
-        "kind",
-        "label",
-        "lang",
-        "list",
-        "loop",
-        "low",
-        "max",
-        "maxlength",
-        "min",
-        "minlength",
-        "multiple",
-        "muted",
-        "name",
-        "optimum",
-        "pattern",
-        "placeholder",
-        "poster",
-        "preload",
-        "readonly",
-        "required",
-        "reversed",
-        "role",
-        "rows",
-        "rowspan",
-        "scope",
-        "selected",
-        "shape",
-        "size",
-        "sizes",
-        "span",
-        "spellcheck",
-        "src",
-        "srclang",
-        "srcset",
-        "start",
-        "step",
-        "style",
-        "tabindex",
-        "target",
-        "title",
-        "translate",
-        "type",
-        "usemap",
-        "value",
-        "width",
-        "wrap",
-    ]
-});
+pub static SAFE_ATTRIBUTES: LazyLock<HashSet<UniCase<&'static str>>> =
+    LazyLock::new(|| {
+        hashset_unicase![
+            "accept",
+            "align",
+            "alt",
+            "autocapitalize",
+            "autoplay",
+            "background",
+            "bgcolor",
+            "border",
+            "buffered",
+            "checked",
+            "cite",
+            "class",
+            "cols",
+            "colspan",
+            "contenteditable",
+            "controls",
+            "coords",
+            "datetime",
+            "decoding",
+            "default",
+            "dir",
+            "dirname",
+            "disabled",
+            "download",
+            "draggable",
+            "for",
+            "form",
+            "headers",
+            "height",
+            "hidden",
+            "high",
+            "href",
+            "hreflang",
+            "id",
+            "inputmode",
+            "ismap",
+            "itemprop",
+            "kind",
+            "label",
+            "lang",
+            "list",
+            "loop",
+            "low",
+            "max",
+            "maxlength",
+            "min",
+            "minlength",
+            "multiple",
+            "muted",
+            "name",
+            "optimum",
+            "pattern",
+            "placeholder",
+            "poster",
+            "preload",
+            "readonly",
+            "required",
+            "reversed",
+            "role",
+            "rows",
+            "rowspan",
+            "scope",
+            "selected",
+            "shape",
+            "size",
+            "sizes",
+            "span",
+            "spellcheck",
+            "src",
+            "srclang",
+            "srcset",
+            "start",
+            "step",
+            "style",
+            "tabindex",
+            "target",
+            "title",
+            "translate",
+            "type",
+            "usemap",
+            "value",
+            "width",
+            "wrap",
+        ]
+    });
 
 /// List of all HTML5 attributes with special boolean behavior.
 ///
@@ -139,35 +140,36 @@ pub static SAFE_ATTRIBUTES: Lazy<HashSet<UniCase<&'static str>>> = Lazy::new(|| 
 ///
 /// This list includes all such attributes, even if they are not part of
 /// `SAFE_ATTRIBUTES`.
-pub static BOOLEAN_ATTRIBUTES: Lazy<HashSet<UniCase<&'static str>>> = Lazy::new(|| {
-    hashset_unicase![
-        "allowfullscreen",
-        "allowpaymentrequest",
-        "async",
-        "autofocus",
-        "autoplay",
-        "checked",
-        "controls",
-        "default",
-        "disabled",
-        "formnovalidate",
-        "hidden",
-        "ismap",
-        "itemscope",
-        "loop",
-        "multiple",
-        "muted",
-        "nomodule",
-        "novalidate",
-        "open",
-        "playsinline",
-        "readonly",
-        "required",
-        "reversed",
-        "selected",
-        "truespeed",
-    ]
-});
+pub static BOOLEAN_ATTRIBUTES: LazyLock<HashSet<UniCase<&'static str>>> =
+    LazyLock::new(|| {
+        hashset_unicase![
+            "allowfullscreen",
+            "allowpaymentrequest",
+            "async",
+            "autofocus",
+            "autoplay",
+            "checked",
+            "controls",
+            "default",
+            "disabled",
+            "formnovalidate",
+            "hidden",
+            "ismap",
+            "itemscope",
+            "loop",
+            "multiple",
+            "muted",
+            "nomodule",
+            "novalidate",
+            "open",
+            "playsinline",
+            "readonly",
+            "required",
+            "reversed",
+            "selected",
+            "truespeed",
+        ]
+    });
 
 /// List of HTML attributes which need to be checked for XSS.
 ///
@@ -178,11 +180,11 @@ pub static BOOLEAN_ATTRIBUTES: Lazy<HashSet<UniCase<&'static str>>> = Lazy::new(
 /// ## See also
 /// * `detect_dangerous_schemes()`
 /// * `normalize_href()`
-pub static URL_ATTRIBUTES: Lazy<HashSet<UniCase<&'static str>>> =
-    Lazy::new(|| hashset_unicase!["href", "src",]);
+pub static URL_ATTRIBUTES: LazyLock<HashSet<UniCase<&'static str>>> =
+    LazyLock::new(|| hashset_unicase!["href", "src",]);
 
-static ATTRIBUTE_SUFFIX_SAFE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"[a-zA-z0-9\-]+").unwrap());
+static ATTRIBUTE_SUFFIX_SAFE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"[a-zA-z0-9\-]+").unwrap());
 
 pub const SAFE_ATTRIBUTE_PREFIXES: [&str; 2] = ["aria-", "data-"];
 

--- a/src/url.rs
+++ b/src/url.rs
@@ -18,9 +18,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use once_cell::sync::Lazy;
 use regex::Regex;
 use std::borrow::Cow;
+use std::sync::LazyLock;
 use wikidot_normalize::normalize;
 
 #[cfg(feature = "html")]
@@ -66,7 +66,8 @@ pub fn is_url(url: &str) -> bool {
 /// funny business going on with the scheme, such as insertion of
 /// whitespace. In such cases, the URL is rejected.
 pub fn dangerous_scheme(url: &str) -> bool {
-    static SCHEME_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[\w\-]+$").unwrap());
+    static SCHEME_REGEX: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^[\w\-]+$").unwrap());
 
     url.split_once(':')
         .map(|(scheme, _)| {


### PR DESCRIPTION
Like with https://github.com/scpwiki/wikijump/pull/2473, this PR removes the `once_cell` dependency and uses the [`LazyLock`](https://doc.rust-lang.org/stable/std/sync/struct.LazyLock.html) struct now in the Rust standard library.