### PR TITLE
Fix duplicate footnotes when parsing rules fail

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = ["parser-implementations"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "1.32.1"
+version = "1.32.2"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2021"
 

--- a/src/parsing/consume.rs
+++ b/src/parsing/consume.rs
@@ -54,6 +54,7 @@ pub fn consume<'r, 't>(parser: &mut Parser<'r, 't>) -> ParseResult<'r, 't, Eleme
         trace!("Trying rule consumption for tokens (rule {})", rule.name());
 
         let old_remaining = parser.remaining();
+        let footnote_count = parser.footnote_count();
         match rule.try_consume(parser) {
             Ok(output) => {
                 debug!("Rule {} matched, returning generated result", rule.name());
@@ -77,6 +78,8 @@ pub fn consume<'r, 't>(parser: &mut Parser<'r, 't>) -> ParseResult<'r, 't, Eleme
             }
             Err(error) => {
                 warn!("Rule failed, returning error: '{}'", error.kind().name());
+                // Rollback footnotes added during failed rule attempt
+                parser.truncate_footnotes(footnote_count);
                 all_errors.push(error);
             }
         }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -252,6 +252,14 @@ impl<'r, 't> Parser<'r, 't> {
         self.footnotes.borrow_mut().push(contents);
     }
 
+    pub fn footnote_count(&self) -> usize {
+        self.footnotes.borrow().len()
+    }
+
+    pub fn truncate_footnotes(&mut self, count: usize) {
+        self.footnotes.borrow_mut().truncate(count);
+    }
+
     #[cold]
     pub fn remove_footnotes(&mut self) -> Vec<Vec<Element<'t>>> {
         mem::take(&mut self.footnotes.borrow_mut())

--- a/test/color/malformed-nested-footnote-bug/errors.json
+++ b/test/color/malformed-nested-footnote-bug/errors.json
@@ -1,0 +1,38 @@
+[
+    {
+        "token": "paragraph-break",
+        "rule": "color",
+        "span": [
+            175,
+            177
+        ],
+        "kind": "rule-failed"
+    },
+    {
+        "token": "color",
+        "rule": "fallback",
+        "span": [
+            84,
+            86
+        ],
+        "kind": "no-rules-match"
+    },
+    {
+        "token": "paragraph-break",
+        "rule": "color",
+        "span": [
+            175,
+            177
+        ],
+        "kind": "rule-failed"
+    },
+    {
+        "token": "color",
+        "rule": "fallback",
+        "span": [
+            101,
+            103
+        ],
+        "kind": "no-rules-match"
+    }
+]

--- a/test/color/malformed-nested-footnote-bug/input.ftml
+++ b/test/color/malformed-nested-footnote-bug/input.ftml
@@ -1,0 +1,5 @@
+This test verifies that malformed color syntax does not cause duplicate footnotes.
+
+##orange|**ORANGE##-PRIME:** text with footnote[[footnote]]This is a footnote[[/footnote]].
+
+After the malformed color block.

--- a/test/color/malformed-nested-footnote-bug/tree.json
+++ b/test/color/malformed-nested-footnote-bug/tree.json
@@ -1,0 +1,278 @@
+{
+    "elements": [
+        {
+            "element": "container",
+            "data": {
+                "type": "paragraph",
+                "attributes": {},
+                "elements": [
+                    {
+                        "element": "text",
+                        "data": "This"
+                    },
+                    {
+                        "element": "text",
+                        "data": " "
+                    },
+                    {
+                        "element": "text",
+                        "data": "test"
+                    },
+                    {
+                        "element": "text",
+                        "data": " "
+                    },
+                    {
+                        "element": "text",
+                        "data": "verifies"
+                    },
+                    {
+                        "element": "text",
+                        "data": " "
+                    },
+                    {
+                        "element": "text",
+                        "data": "that"
+                    },
+                    {
+                        "element": "text",
+                        "data": " "
+                    },
+                    {
+                        "element": "text",
+                        "data": "malformed"
+                    },
+                    {
+                        "element": "text",
+                        "data": " "
+                    },
+                    {
+                        "element": "text",
+                        "data": "color"
+                    },
+                    {
+                        "element": "text",
+                        "data": " "
+                    },
+                    {
+                        "element": "text",
+                        "data": "syntax"
+                    },
+                    {
+                        "element": "text",
+                        "data": " "
+                    },
+                    {
+                        "element": "text",
+                        "data": "does"
+                    },
+                    {
+                        "element": "text",
+                        "data": " "
+                    },
+                    {
+                        "element": "text",
+                        "data": "not"
+                    },
+                    {
+                        "element": "text",
+                        "data": " "
+                    },
+                    {
+                        "element": "text",
+                        "data": "cause"
+                    },
+                    {
+                        "element": "text",
+                        "data": " "
+                    },
+                    {
+                        "element": "text",
+                        "data": "duplicate"
+                    },
+                    {
+                        "element": "text",
+                        "data": " "
+                    },
+                    {
+                        "element": "text",
+                        "data": "footnotes"
+                    },
+                    {
+                        "element": "text",
+                        "data": "."
+                    }
+                ]
+            }
+        },
+        {
+            "element": "container",
+            "data": {
+                "type": "paragraph",
+                "attributes": {},
+                "elements": [
+                    {
+                        "element": "text",
+                        "data": "##"
+                    },
+                    {
+                        "element": "text",
+                        "data": "orange"
+                    },
+                    {
+                        "element": "text",
+                        "data": "|"
+                    },
+                    {
+                        "element": "container",
+                        "data": {
+                            "type": "bold",
+                            "attributes": {},
+                            "elements": [
+                                {
+                                    "element": "text",
+                                    "data": "ORANGE"
+                                },
+                                {
+                                    "element": "text",
+                                    "data": "##"
+                                },
+                                {
+                                    "element": "text",
+                                    "data": "-"
+                                },
+                                {
+                                    "element": "text",
+                                    "data": "PRIME"
+                                },
+                                {
+                                    "element": "text",
+                                    "data": ":"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "element": "text",
+                        "data": " "
+                    },
+                    {
+                        "element": "text",
+                        "data": "text"
+                    },
+                    {
+                        "element": "text",
+                        "data": " "
+                    },
+                    {
+                        "element": "text",
+                        "data": "with"
+                    },
+                    {
+                        "element": "text",
+                        "data": " "
+                    },
+                    {
+                        "element": "text",
+                        "data": "footnote"
+                    },
+                    {
+                        "element": "footnote"
+                    },
+                    {
+                        "element": "text",
+                        "data": "."
+                    }
+                ]
+            }
+        },
+        {
+            "element": "container",
+            "data": {
+                "type": "paragraph",
+                "attributes": {},
+                "elements": [
+                    {
+                        "element": "text",
+                        "data": "After"
+                    },
+                    {
+                        "element": "text",
+                        "data": " "
+                    },
+                    {
+                        "element": "text",
+                        "data": "the"
+                    },
+                    {
+                        "element": "text",
+                        "data": " "
+                    },
+                    {
+                        "element": "text",
+                        "data": "malformed"
+                    },
+                    {
+                        "element": "text",
+                        "data": " "
+                    },
+                    {
+                        "element": "text",
+                        "data": "color"
+                    },
+                    {
+                        "element": "text",
+                        "data": " "
+                    },
+                    {
+                        "element": "text",
+                        "data": "block"
+                    },
+                    {
+                        "element": "text",
+                        "data": "."
+                    }
+                ]
+            }
+        },
+        {
+            "element": "footnote-block",
+            "data": {
+                "title": null,
+                "hide": false
+            }
+        }
+    ],
+    "footnotes": [
+        [
+            {
+                "element": "text",
+                "data": "This"
+            },
+            {
+                "element": "text",
+                "data": " "
+            },
+            {
+                "element": "text",
+                "data": "is"
+            },
+            {
+                "element": "text",
+                "data": " "
+            },
+            {
+                "element": "text",
+                "data": "a"
+            },
+            {
+                "element": "text",
+                "data": " "
+            },
+            {
+                "element": "text",
+                "data": "footnote"
+            }
+        ]
+    ]
+}

--- a/test/color/malformed-nested/errors.json
+++ b/test/color/malformed-nested/errors.json
@@ -1,0 +1,74 @@
+[
+    {
+        "token": "input-end",
+        "rule": "color",
+        "span": [
+            235,
+            235
+        ],
+        "kind": "end-of-input"
+    },
+    {
+        "token": "color",
+        "rule": "fallback",
+        "span": [
+            2,
+            4
+        ],
+        "kind": "no-rules-match"
+    },
+    {
+        "token": "line-break",
+        "rule": "color",
+        "span": [
+            78,
+            79
+        ],
+        "kind": "rule-failed"
+    },
+    {
+        "token": "color",
+        "rule": "fallback",
+        "span": [
+            19,
+            21
+        ],
+        "kind": "no-rules-match"
+    },
+    {
+        "token": "input-end",
+        "rule": "color",
+        "span": [
+            235,
+            235
+        ],
+        "kind": "end-of-input"
+    },
+    {
+        "token": "color",
+        "rule": "fallback",
+        "span": [
+            169,
+            171
+        ],
+        "kind": "no-rules-match"
+    },
+    {
+        "token": "input-end",
+        "rule": "color",
+        "span": [
+            235,
+            235
+        ],
+        "kind": "end-of-input"
+    },
+    {
+        "token": "color",
+        "rule": "fallback",
+        "span": [
+            186,
+            188
+        ],
+        "kind": "no-rules-match"
+    }
+]

--- a/test/color/malformed-nested/input.ftml
+++ b/test/color/malformed-nested/input.ftml
@@ -1,0 +1,5 @@
+> ##orange|**ORANGE##-PRIME:** {{**[Death. Noun. 1. The cessation of life]**}}
+> 
+> **Stump:** I mean, we do die[[footnote]] Note here [[/footnote]]. Pretty often.
+> 
+> ##orange|**ORANGE##-PRIME:** {{**[That is] [EXCELLENT!] [news]**}}

--- a/test/color/malformed-nested/tree.json
+++ b/test/color/malformed-nested/tree.json
@@ -1,0 +1,403 @@
+{
+    "elements": [
+        {
+            "element": "container",
+            "data": {
+                "type": "blockquote",
+                "attributes": {},
+                "elements": [
+                    {
+                        "element": "container",
+                        "data": {
+                            "type": "paragraph",
+                            "attributes": {},
+                            "elements": [
+                                {
+                                    "element": "text",
+                                    "data": "##"
+                                },
+                                {
+                                    "element": "text",
+                                    "data": "orange"
+                                },
+                                {
+                                    "element": "text",
+                                    "data": "|"
+                                },
+                                {
+                                    "element": "container",
+                                    "data": {
+                                        "type": "bold",
+                                        "attributes": {},
+                                        "elements": [
+                                            {
+                                                "element": "text",
+                                                "data": "ORANGE"
+                                            },
+                                            {
+                                                "element": "text",
+                                                "data": "##"
+                                            },
+                                            {
+                                                "element": "text",
+                                                "data": "-"
+                                            },
+                                            {
+                                                "element": "text",
+                                                "data": "PRIME"
+                                            },
+                                            {
+                                                "element": "text",
+                                                "data": ":"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "element": "text",
+                                    "data": " "
+                                },
+                                {
+                                    "element": "container",
+                                    "data": {
+                                        "type": "monospace",
+                                        "attributes": {},
+                                        "elements": [
+                                            {
+                                                "element": "container",
+                                                "data": {
+                                                    "type": "bold",
+                                                    "attributes": {},
+                                                    "elements": [
+                                                        {
+                                                            "element": "text",
+                                                            "data": "["
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": "Death"
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": "."
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": " "
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": "Noun"
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": "."
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": " "
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": "1"
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": "."
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": " "
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": "The"
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": " "
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": "cessation"
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": " "
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": "of"
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": " "
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": "life"
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": "]"
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "element": "line-break"
+                                },
+                                {
+                                    "element": "line-break"
+                                },
+                                {
+                                    "element": "container",
+                                    "data": {
+                                        "type": "bold",
+                                        "attributes": {},
+                                        "elements": [
+                                            {
+                                                "element": "text",
+                                                "data": "Stump"
+                                            },
+                                            {
+                                                "element": "text",
+                                                "data": ":"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "element": "text",
+                                    "data": " "
+                                },
+                                {
+                                    "element": "text",
+                                    "data": "I"
+                                },
+                                {
+                                    "element": "text",
+                                    "data": " "
+                                },
+                                {
+                                    "element": "text",
+                                    "data": "mean"
+                                },
+                                {
+                                    "element": "text",
+                                    "data": ","
+                                },
+                                {
+                                    "element": "text",
+                                    "data": " "
+                                },
+                                {
+                                    "element": "text",
+                                    "data": "we"
+                                },
+                                {
+                                    "element": "text",
+                                    "data": " "
+                                },
+                                {
+                                    "element": "text",
+                                    "data": "do"
+                                },
+                                {
+                                    "element": "text",
+                                    "data": " "
+                                },
+                                {
+                                    "element": "text",
+                                    "data": "die"
+                                },
+                                {
+                                    "element": "footnote"
+                                },
+                                {
+                                    "element": "text",
+                                    "data": "."
+                                },
+                                {
+                                    "element": "text",
+                                    "data": " "
+                                },
+                                {
+                                    "element": "text",
+                                    "data": "Pretty"
+                                },
+                                {
+                                    "element": "text",
+                                    "data": " "
+                                },
+                                {
+                                    "element": "text",
+                                    "data": "often"
+                                },
+                                {
+                                    "element": "text",
+                                    "data": "."
+                                },
+                                {
+                                    "element": "line-break"
+                                },
+                                {
+                                    "element": "line-break"
+                                },
+                                {
+                                    "element": "text",
+                                    "data": "##"
+                                },
+                                {
+                                    "element": "text",
+                                    "data": "orange"
+                                },
+                                {
+                                    "element": "text",
+                                    "data": "|"
+                                },
+                                {
+                                    "element": "container",
+                                    "data": {
+                                        "type": "bold",
+                                        "attributes": {},
+                                        "elements": [
+                                            {
+                                                "element": "text",
+                                                "data": "ORANGE"
+                                            },
+                                            {
+                                                "element": "text",
+                                                "data": "##"
+                                            },
+                                            {
+                                                "element": "text",
+                                                "data": "-"
+                                            },
+                                            {
+                                                "element": "text",
+                                                "data": "PRIME"
+                                            },
+                                            {
+                                                "element": "text",
+                                                "data": ":"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "element": "text",
+                                    "data": " "
+                                },
+                                {
+                                    "element": "container",
+                                    "data": {
+                                        "type": "monospace",
+                                        "attributes": {},
+                                        "elements": [
+                                            {
+                                                "element": "container",
+                                                "data": {
+                                                    "type": "bold",
+                                                    "attributes": {},
+                                                    "elements": [
+                                                        {
+                                                            "element": "text",
+                                                            "data": "["
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": "That"
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": " "
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": "is"
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": "]"
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": " "
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": "["
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": "EXCELLENT"
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": "!"
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": "]"
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": " "
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": "["
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": "news"
+                                                        },
+                                                        {
+                                                            "element": "text",
+                                                            "data": "]"
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "element": "footnote-block",
+            "data": {
+                "title": null,
+                "hide": false
+            }
+        }
+    ],
+    "footnotes": [
+        [
+            {
+                "element": "text",
+                "data": "Note"
+            },
+            {
+                "element": "text",
+                "data": " "
+            },
+            {
+                "element": "text",
+                "data": "here"
+            },
+            {
+                "element": "text",
+                "data": " "
+            }
+        ]
+    ]
+}


### PR DESCRIPTION
**NOTE:** This PR is a recreation of #48

## Summary

Fixes a bug where the parser generates 8,196 duplicate footnotes when encountering malformed color syntax.

## Problem

When parsing Fragment 3 of dyfscp0012 (SCP-001 proposal), the parser generates:
- **Actual**: 8,196 footnotes (8,191 duplicates of 5 unique footnotes)
- **Expected**: ~5 footnotes

The issue is triggered by malformed color syntax: `##orange|**ORANGE##-PRIME:**` where the closing `##` appears before the end of the bold markers.

## Solution

The parser uses shared `Rc<RefCell<>>` for storing footnotes. When parsing rules fail and retry, footnotes were not being rolled back, causing duplicates.

This PR adds:
- Footnote count tracking before trying each parsing rule
- Rollback mechanism to truncate footnotes when rules fail
- Helper methods: `footnote_count()` and `truncate_footnotes()`

## Test Cases

Added comprehensive test cases:
- `test/color/malformed-nested/` - Tests malformed color syntax parsing
- `test/color/malformed-nested-footnote-bug/` - Verifies no footnote duplication

## Verification

- All existing AST tests pass
- New test cases verify correct footnote count (1 footnote, not thousands)
- Malformed color syntax now handled gracefully without side effects