### PR TITLE
Add [[raw]] block for multiline raw input

### DIFF
--- a/conf/blocks.toml
+++ b/conf/blocks.toml
@@ -269,6 +269,12 @@ body = "none"
 html-attributes = true
 html-output = "html,input"
 
+[raw]
+accepts-newlines = true
+head = "map"
+body = "raw"
+html-output = "html,span,wj-raw"
+
 [ruby]
 accepts-newlines = true
 head = "map"

--- a/conf/blocks.toml
+++ b/conf/blocks.toml
@@ -270,7 +270,7 @@ html-attributes = true
 html-output = "html,input"
 
 [raw]
-accepts-newlines = true
+accepts-newlines = false
 head = "map"
 body = "raw"
 html-output = "html,span,wj-raw"

--- a/docs/Blocks.md
+++ b/docs/Blocks.md
@@ -78,59 +78,60 @@ A list of all blocks and their attributes is available at [`conf/blocks.toml`](.
 
 Alternatively you may look here for a formatted list: (though it may not be updated as consistently)
 
-| Block Name                              | Accepted Names                   | Star? | Score? | Newlines? | Argument Type | Body Type |
-|-----------------------------------------|----------------------------------|-------|--------|-----------|---------------|-----------|
-| [Anchor](#anchor)                       | `a`, `anchor`                    | No    | Yes    | No        | Map           | Elements  |
-| [Bibliography Citation](#bibliography-citation) | `bibcite`                | No    | Yes    | No        | Value         | None      |
-| [Bibliography](#bibliography-block)     | `bibliography`                   | No    | No     | Yes       | Map           | (See below) |
-| [Blockquote](#blockquote)               | `blockquote`, `quote`            | No    | No     | Yes       | Map           | Elements  |
-| [Bold](#bold)                           | `b`, `bold`, `strong`            | No    | No     | No        | Map           | Elements  |
-| [Char](#char)                           | `char`, `character`              | No    | No     | No        | Value         | None      |
-| [Checkbox](#checkbox)                   | `checkbox`                       | Yes   | No     | No        | Map           | None      |
-| [Code](#code)                           | `code`                           | No    | No     | Yes       | Map           | Raw       |
-| [Collapsible](#collapsible)             | `collapsible`                    | No    | No     | Yes       | Map           | Elements  |
-| [Date](#date)                           | `date`                           | No    | No     | No        | Value + Map   | None      |
-| [Deletion](#deletion)                   | `del`, `deletion`                | No    | No     | No        | Map           | Elements  |
-| [Div](#div)                             | `div`                            | No    | Yes    | Yes       | Map           | Elements  |
-| [Embed](#embed)                         | `embed`                          | No    | No     | Yes       | Value + Map   | None      |
-| [Equation Reference](#equation-ref)     | `equation`, `eref`, `eqref`      | No    | No     | No        | Value         | None      |
-| [Footnote](#footnote)                   | `footnote`                       | No    | No     | No        | None          | Elements  |
-| [Footnote Block](#footnote-block)       | `footnoteblock`                  | No    | No     | Yes       | Map           | None      |
-| [Hidden](#hidden)                       | `hidden`                         | No    | No     | Yes       | Map           | Elements  |
-| [HTML](#html)                           | `html`                           | No    | No     | Yes       | Map           | Raw       |
-| [IfCategory](#ifcategory)               | `ifcategory`                     | No    | No     | Yes       | Value         | Elements  |
-| [IfTags](#iftags)                       | `iftags`                         | No    | No     | Yes       | Value         | Elements  |
-| [Iframe](#iframe)                       | `iframe`                         | No    | No     | Yes       | Value + Map   | None      |
-| [Image](#image)                         | `image`                          | No    | No     | No        | Value + Map   | None      |
-| [Include (Elements)](#include-elements) | `include-elements`               | No    | No     | Yes       | Value + Map   | None      |
-| [Include (Wikidot)](#include-wikidot)   | `include`                        | No    | No     | Yes       | Value + Map   | None      |
-| [Insertion](#insertion)                 | `ins`, `insertion`               | No    | No     | No        | Map           | Elements  |
-| [Invisible](#invisible)                 | `invisible`                      | No    | No     | Yes       | Map           | Elements  |
-| [Italics](#italics)                     | `i`, `italics`, `em`, `emphasis` | No    | No     | No        | Map           | Elements  |
-| [Lines](#lines)                         | `lines`, `newlines`              | No    | No     | Yes       | Value         | None      |
-| [List Blocks](#list)                    | `ul`, `ol`, `li`                 | No    | Yes    | Yes       | Map           | Elements  |
-| [Mark](#mark)                           | `mark`, `highlight`              | No    | No     | No        | Map           | Elements  |
-| [Math](#math)                           | `math`                           | No    | No     | Yes       | Value         | Raw       |
-| [Math (Inline)](#math-inline)           | (See below)                      | No    | No     | No        | (See below)   | (See below) |
-| [Module](#module)                       | `module`                         | No    | No     | Yes       | (See below)   | (See below) |
-| [Monospace](#monospace)                 | `tt`, `mono`, `monospace`        | No    | No     | No        | Map           | Elements  |
-| [Paragraph](#paragraph)                 | `p`, `paragraph`                 | No    | No     | Yes       | Map           | Elements  |
-| [Radio](#radio)                         | `radio`, `radio-button`          | Yes   | No     | No        | Value + Map   | None      |
-| [Ruby](#ruby)                           | `ruby`                           | No    | No     | Yes       | Map           | Elements  |
-| [Ruby text](#ruby-text)                 | `rt`, `rubytext`                 | No    | No     | Yes       | Map           | Elements  |
-| [Ruby (short)](#ruby-short)             | `rb`, `ruby2`                    | No    | No     | Yes       | Value         | None      |
-| [Size](#size)                           | `size`                           | No    | No     | No        | Value         | Elements  |
-| [Span](#span)                           | `span`                           | No    | Yes    | No        | Map           | Elements  |
-| [Strikethrough](#strikethrough)         | `s`, `strikethrough`             | No    | No     | No        | Map           | Elements  |
-| [Subscript](#subscript)                 | `sub`, `subscript`               | No    | No     | No        | Map           | Elements  |
-| [Superscript](#superscript)             | `sup`, `super`, `superscript`    | No    | No     | No        | Map           | Elements  |
-| [Tables](#tables)                       | `table`, `row`, `cell`, `hcell`  | No    | No     | Yes       | Map           | Elements  |
-| [Tab Views](#tabs)                      | `tabview`, `tabs`                | No    | No     | Yes       | None          | Elements  |
-| [Tabs](#tabs)                           | `tab`                            | No    | No     | Yes       | Value         | Elements  |
-| [Target](#target)                       | `target`, `anchortarget`         | No    | No     | Yes       | Value         | None      |
-| [TOC](#toc)                             | `toc`                            | No    | No     | Yes       | Map           | None      |
-| [Underline](#underline)                 | `u`, `underline`                 | No    | No     | No        | Map           | Elements  |
-| [User](#user)                           | `user`                           | Yes   | No     | No        | Value         | None      |
+| Block Name                                      | Accepted Names                   | Star? | Score? | Newlines? | Argument Type | Body Type |
+|-------------------------------------------------|----------------------------------|-------|--------|-----------|---------------|-----------|
+| [Anchor](#anchor)                               | `a`, `anchor`                    | No    | Yes    | No        | Map           | Elements  |
+| [Bibliography Citation](#bibliography-citation) | `bibcite`                        | No    | Yes    | No        | Value         | None      |
+| [Bibliography](#bibliography-block)             | `bibliography`                   | No    | No     | Yes       | Map           | (See below) |
+| [Blockquote](#blockquote)                       | `blockquote`, `quote`            | No    | No     | Yes       | Map           | Elements  |
+| [Bold](#bold)                                   | `b`, `bold`, `strong`            | No    | No     | No        | Map           | Elements  |
+| [Char](#char)                                   | `char`, `character`              | No    | No     | No        | Value         | None      |
+| [Checkbox](#checkbox)                           | `checkbox`                       | Yes   | No     | No        | Map           | None      |
+| [Code](#code)                                   | `code`                           | No    | No     | Yes       | Map           | Raw       |
+| [Collapsible](#collapsible)                     | `collapsible`                    | No    | No     | Yes       | Map           | Elements  |
+| [Date](#date)                                   | `date`                           | No    | No     | No        | Value + Map   | None      |
+| [Deletion](#deletion)                           | `del`, `deletion`                | No    | No     | No        | Map           | Elements  |
+| [Div](#div)                                     | `div`                            | No    | Yes    | Yes       | Map           | Elements  |
+| [Embed](#embed)                                 | `embed`                          | No    | No     | Yes       | Value + Map   | None      |
+| [Equation Reference](#equation-ref)             | `equation`, `eref`, `eqref`      | No    | No     | No        | Value         | None      |
+| [Footnote](#footnote)                           | `footnote`                       | No    | No     | No        | None          | Elements  |
+| [Footnote Block](#footnote-block)               | `footnoteblock`                  | No    | No     | Yes       | Map           | None      |
+| [Hidden](#hidden)                               | `hidden`                         | No    | No     | Yes       | Map           | Elements  |
+| [HTML](#html)                                   | `html`                           | No    | No     | Yes       | Map           | Raw       |
+| [IfCategory](#ifcategory)                       | `ifcategory`                     | No    | No     | Yes       | Value         | Elements  |
+| [IfTags](#iftags)                               | `iftags`                         | No    | No     | Yes       | Value         | Elements  |
+| [Iframe](#iframe)                               | `iframe`                         | No    | No     | Yes       | Value + Map   | None      |
+| [Image](#image)                                 | `image`                          | No    | No     | No        | Value + Map   | None      |
+| [Include (Elements)](#include-elements)         | `include-elements`               | No    | No     | Yes       | Value + Map   | None      |
+| [Include (Wikidot)](#include-wikidot)           | `include`                        | No    | No     | Yes       | Value + Map   | None      |
+| [Insertion](#insertion)                         | `ins`, `insertion`               | No    | No     | No        | Map           | Elements  |
+| [Invisible](#invisible)                         | `invisible`                      | No    | No     | Yes       | Map           | Elements  |
+| [Italics](#italics)                             | `i`, `italics`, `em`, `emphasis` | No    | No     | No        | Map           | Elements  |
+| [Lines](#lines)                                 | `lines`, `newlines`              | No    | No     | Yes       | Value         | None      |
+| [List Blocks](#list)                            | `ul`, `ol`, `li`                 | No    | Yes    | Yes       | Map           | Elements  |
+| [Mark](#mark)                                   | `mark`, `highlight`              | No    | No     | No        | Map           | Elements  |
+| [Math](#math)                                   | `math`                           | No    | No     | Yes       | Value         | Raw       |
+| [Math (Inline)](#math-inline)                   | (See below)                      | No    | No     | No        | (See below)   | (See below) |
+| [Module](#module)                               | `module`                         | No    | No     | Yes       | (See below)   | (See below) |
+| [Monospace](#monospace)                         | `tt`, `mono`, `monospace`        | No    | No     | No        | Map           | Elements  |
+| [Paragraph](#paragraph)                         | `p`, `paragraph`                 | No    | No     | Yes       | Map           | Elements  |
+| [Radio](#radio)                                 | `radio`, `radio-button`          | Yes   | No     | No        | Value + Map   | None      |
+| [Raw](#raw)                                     | `raw`                            | No    | No     | Yes       | None          | Raw       |
+| [Ruby](#ruby)                                   | `ruby`                           | No    | No     | Yes       | Map           | Elements  |
+| [Ruby text](#ruby-text)                         | `rt`, `rubytext`                 | No    | No     | Yes       | Map           | Elements  |
+| [Ruby (short)](#ruby-short)                     | `rb`, `ruby2`                    | No    | No     | Yes       | Value         | None      |
+| [Size](#size)                                   | `size`                           | No    | No     | No        | Value         | Elements  |
+| [Span](#span)                                   | `span`                           | No    | Yes    | No        | Map           | Elements  |
+| [Strikethrough](#strikethrough)                 | `s`, `strikethrough`             | No    | No     | No        | Map           | Elements  |
+| [Subscript](#subscript)                         | `sub`, `subscript`               | No    | No     | No        | Map           | Elements  |
+| [Superscript](#superscript)                     | `sup`, `super`, `superscript`    | No    | No     | No        | Map           | Elements  |
+| [Tables](#tables)                               | `table`, `row`, `cell`, `hcell`  | No    | No     | Yes       | Map           | Elements  |
+| [Tab Views](#tabs)                              | `tabview`, `tabs`                | No    | No     | Yes       | None          | Elements  |
+| [Tabs](#tabs)                                   | `tab`                            | No    | No     | Yes       | Value         | Elements  |
+| [Target](#target)                               | `target`, `anchortarget`         | No    | No     | Yes       | Value         | None      |
+| [TOC](#toc)                                     | `toc`                            | No    | No     | Yes       | Map           | None      |
+| [Underline](#underline)                         | `u`, `underline`                 | No    | No     | No        | Map           | Elements  |
+| [User](#user)                                   | `user`                           | Yes   | No     | No        | Value         | None      |
 
 Each of the blocks will be described in more detail below:
 
@@ -800,6 +801,25 @@ Favorite kind of music:
 [[radio music]] Dance
 [[radio music]] Rap
 [[*radio music]] Noise
+```
+
+### Raw
+
+Outputs: `Element::Raw` / `<span class="wj-raw">`
+
+Body: Raw
+
+Accepts newline separation.
+
+Arguments:
+* None
+
+Example:
+
+```
+[[raw]]
+This text is **not** rendered as Wikitext, but output as-is!
+[[/raw]]
 ```
 
 ### Ruby

--- a/src/parsing/rule/impls/block/blocks/mod.rs
+++ b/src/parsing/rule/impls/block/blocks/mod.rs
@@ -94,6 +94,7 @@ mod module;
 mod monospace;
 mod paragraph;
 mod radio;
+mod raw;
 mod ruby;
 mod size;
 mod span;
@@ -106,7 +107,6 @@ mod target;
 mod toc;
 mod underline;
 mod user;
-mod raw;
 
 pub use self::align_center::BLOCK_ALIGN_CENTER;
 pub use self::align_justify::BLOCK_ALIGN_JUSTIFY;

--- a/src/parsing/rule/impls/block/blocks/mod.rs
+++ b/src/parsing/rule/impls/block/blocks/mod.rs
@@ -106,6 +106,7 @@ mod target;
 mod toc;
 mod underline;
 mod user;
+mod raw;
 
 pub use self::align_center::BLOCK_ALIGN_CENTER;
 pub use self::align_justify::BLOCK_ALIGN_JUSTIFY;
@@ -146,6 +147,7 @@ pub use self::module::BLOCK_MODULE;
 pub use self::monospace::BLOCK_MONOSPACE;
 pub use self::paragraph::BLOCK_PARAGRAPH;
 pub use self::radio::BLOCK_RADIO;
+pub use self::raw::BLOCK_RAW;
 pub use self::ruby::{BLOCK_RB, BLOCK_RT, BLOCK_RUBY};
 pub use self::size::BLOCK_SIZE;
 pub use self::span::BLOCK_SPAN;

--- a/src/parsing/rule/impls/block/blocks/raw.rs
+++ b/src/parsing/rule/impls/block/blocks/raw.rs
@@ -48,7 +48,8 @@ fn parse_fn<'r, 't>(
     if content.eq("\n") {
         content = "";
     }
-    // Trim the first and last \n if it's a multi-line block
+    // Trim the first and last \n if it's a multi-line block.
+    // We already checked for the single newline case above.
     else if content.starts_with('\n') && content.ends_with('\n') {
         content = content.trim_start_matches('\n').trim_end_matches('\n');
     }

--- a/src/parsing/rule/impls/block/blocks/raw.rs
+++ b/src/parsing/rule/impls/block/blocks/raw.rs
@@ -1,0 +1,65 @@
+/*
+ * parsing/rule/impls/block/blocks/raw.rs
+ *
+ * ftml - Library to parse Wikidot text
+ * Copyright (C) 2019-2025 Wikijump Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+use super::prelude::*;
+
+pub const BLOCK_RAW: BlockRule = BlockRule {
+    name: "block-raw",
+    accepts_names: &["raw"],
+    accepts_star: false,
+    accepts_score: false,
+    accepts_newlines: true,
+    parse_fn,
+};
+
+fn parse_fn<'r, 't>(
+    parser: &mut Parser<'r, 't>,
+    name: &'t str,
+    flag_star: bool,
+    flag_score: bool,
+    in_head: bool,
+) -> ParseResult<'r, 't, Elements<'t>> {
+    trace!("Parsing raw block (name '{name}', in-head {in_head}, score {flag_score})");
+    assert!(!flag_star, "Raw doesn't allow star flag");
+    assert!(!flag_score, "Raw doesn't allow score flag");
+
+    assert_block_name(&BLOCK_RAW, name);
+
+    let (start, mut end) = {
+        let current = parser.current();
+
+        (current, current)
+    };
+    loop {
+        match parser.get_end_block() {
+            Ok(n) => {
+                if n == name {
+                    trace!("Parsing block start: {start:?}, end: {end:?}, name: {name})");
+                    let slice = parser.full_text().slice_partial(start, end);
+                    let element = Element::Raw(cow!(slice));
+                    return ok!(element);
+                }
+            },
+            Err(_e) => {
+            }
+        };
+        trace!("Appending present token to raw");
+        end = parser.step()?;
+    }
+}

--- a/src/parsing/rule/impls/block/blocks/raw.rs
+++ b/src/parsing/rule/impls/block/blocks/raw.rs
@@ -46,7 +46,7 @@ fn parse_fn<'r, 't>(
 
     // Empty block
     if content.eq("\n") {
-        content = ""
+        content = "";
     }
     // Trim the first and last \n if it's a multi-line block
     else if content.starts_with('\n') && content.ends_with('\n') && content.len() >= 2 {

--- a/src/parsing/rule/impls/block/blocks/raw.rs
+++ b/src/parsing/rule/impls/block/blocks/raw.rs
@@ -47,19 +47,17 @@ fn parse_fn<'r, 't>(
         (current, current)
     };
     loop {
-        match parser.get_end_block() {
-            Ok(n) => {
-                if n == name {
-                    trace!("Parsing block start: {start:?}, end: {end:?}, name: {name})");
-                    let slice = parser.full_text().slice_partial(start, end);
-                    let element = Element::Raw(cow!(slice));
-                    return ok!(element);
-                }
-            },
-            Err(_e) => {
+        // Check if we reach an end block token
+        if let Ok(found_name) = parser.get_end_block() {
+            // If so, check if it's a raw end block token
+            if found_name == name {
+                trace!("Parsing block start: {start:?}, end: {end:?}, name: {name})");
+                let slice = parser.full_text().slice_partial(start, end);
+                let element = Element::Raw(cow!(slice));
+                return ok!(element);
             }
-        };
-        trace!("Appending present token to raw");
+        }
+        // Update last token and step.
         end = parser.step()?;
     }
 }

--- a/src/parsing/rule/impls/block/blocks/raw.rs
+++ b/src/parsing/rule/impls/block/blocks/raw.rs
@@ -49,7 +49,7 @@ fn parse_fn<'r, 't>(
         content = "";
     }
     // Trim the first and last \n if it's a multi-line block
-    else if content.starts_with('\n') && content.ends_with('\n') && content.len() >= 2 {
+    else if content.starts_with('\n') && content.ends_with('\n') {
         content = content.trim_start_matches('\n').trim_end_matches('\n');
     }
 

--- a/src/parsing/rule/impls/block/blocks/raw.rs
+++ b/src/parsing/rule/impls/block/blocks/raw.rs
@@ -19,12 +19,12 @@
  */
 use super::prelude::*;
 
+// accepts_newlines needs to be false here to avoid end trimming from get_body_text
 pub const BLOCK_RAW: BlockRule = BlockRule {
     name: "block-raw",
     accepts_names: &["raw"],
     accepts_star: false,
     accepts_score: false,
-    // accepts_newlines needs to be false here to avoid end trimming from get_body_text
     accepts_newlines: false,
     parse_fn,
 };

--- a/src/parsing/rule/impls/block/blocks/raw.rs
+++ b/src/parsing/rule/impls/block/blocks/raw.rs
@@ -19,7 +19,7 @@
  */
 use super::prelude::*;
 
-// accepts_newlines needs to be false here to avoid end trimming from get_body_text
+// NOTE: "accepts_newlines" needs to be false here to avoid end trimming from get_body_text
 pub const BLOCK_RAW: BlockRule = BlockRule {
     name: "block-raw",
     accepts_names: &["raw"],

--- a/src/parsing/rule/impls/block/mapping.rs
+++ b/src/parsing/rule/impls/block/mapping.rs
@@ -23,7 +23,7 @@ use std::collections::HashMap;
 use std::sync::LazyLock;
 use unicase::UniCase;
 
-pub const BLOCK_RULES: [BlockRule; 60] = [
+pub const BLOCK_RULES: [BlockRule; 61] = [
     BLOCK_ALIGN_CENTER,
     BLOCK_ALIGN_JUSTIFY,
     BLOCK_ALIGN_LEFT,
@@ -65,6 +65,7 @@ pub const BLOCK_RULES: [BlockRule; 60] = [
     BLOCK_OL,
     BLOCK_PARAGRAPH,
     BLOCK_RADIO,
+    BLOCK_RAW,
     BLOCK_RB,
     BLOCK_RT,
     BLOCK_RUBY,

--- a/test/raw/block/input.ftml
+++ b/test/raw/block/input.ftml
@@ -1,0 +1,30 @@
+BASIC
+[[raw]]
+apple
+banana
+[[/raw]]
+
+EMPTY
+[[raw]]
+[[/raw]]
+
+ESCAPES
+[[raw]]
+[[div]]
+not a div test
+[[/div]]
+
+**also not bold**
+[[/raw]]
+
+INLINE
+[[raw]]a { display: none; }[[/raw]]
+
+MULTI
+[[raw]]
+first block
+[[/raw]]
+
+[[raw]]
+second block
+[[/raw]]

--- a/test/raw/block/tree.json
+++ b/test/raw/block/tree.json
@@ -11,8 +11,11 @@
                         "data": "BASIC"
                     },
                     {
+                        "element": "line-break"
+                    },
+                    {
                         "element": "raw",
-                        "data": "\napple\nbanana\n"
+                        "data": "apple\nbanana"
                     }
                 ]
             }
@@ -28,8 +31,11 @@
                         "data": "EMPTY"
                     },
                     {
+                        "element": "line-break"
+                    },
+                    {
                         "element": "raw",
-                        "data": "\n"
+                        "data": ""
                     }
                 ]
             }
@@ -45,8 +51,11 @@
                         "data": "ESCAPES"
                     },
                     {
+                        "element": "line-break"
+                    },
+                    {
                         "element": "raw",
-                        "data": "\n[[div]]\nnot a div test\n[[/div]]\n\n**also not bold**\n"
+                        "data": "[[div]]\nnot a div test\n[[/div]]\n\n**also not bold**"
                     }
                 ]
             }
@@ -60,6 +69,9 @@
                     {
                         "element": "text",
                         "data": "INLINE"
+                    },
+                    {
+                        "element": "line-break"
                     },
                     {
                         "element": "raw",
@@ -79,8 +91,11 @@
                         "data": "MULTI"
                     },
                     {
+                        "element": "line-break"
+                    },
+                    {
                         "element": "raw",
-                        "data": "\nfirst block\n"
+                        "data": "first block"
                     }
                 ]
             }
@@ -93,7 +108,7 @@
                 "elements": [
                     {
                         "element": "raw",
-                        "data": "\nsecond block\n"
+                        "data": "second block"
                     }
                 ]
             }

--- a/test/raw/block/tree.json
+++ b/test/raw/block/tree.json
@@ -1,0 +1,109 @@
+{
+    "elements": [
+        {
+            "element": "container",
+            "data": {
+                "type": "paragraph",
+                "attributes": {},
+                "elements": [
+                    {
+                        "element": "text",
+                        "data": "BASIC"
+                    },
+                    {
+                        "element": "raw",
+                        "data": "\napple\nbanana\n"
+                    }
+                ]
+            }
+        },
+        {
+            "element": "container",
+            "data": {
+                "type": "paragraph",
+                "attributes": {},
+                "elements": [
+                    {
+                        "element": "text",
+                        "data": "EMPTY"
+                    },
+                    {
+                        "element": "raw",
+                        "data": "\n"
+                    }
+                ]
+            }
+        },
+        {
+            "element": "container",
+            "data": {
+                "type": "paragraph",
+                "attributes": {},
+                "elements": [
+                    {
+                        "element": "text",
+                        "data": "ESCAPES"
+                    },
+                    {
+                        "element": "raw",
+                        "data": "\n[[div]]\nnot a div test\n[[/div]]\n\n**also not bold**\n"
+                    }
+                ]
+            }
+        },
+        {
+            "element": "container",
+            "data": {
+                "type": "paragraph",
+                "attributes": {},
+                "elements": [
+                    {
+                        "element": "text",
+                        "data": "INLINE"
+                    },
+                    {
+                        "element": "raw",
+                        "data": "a { display: none; }"
+                    }
+                ]
+            }
+        },
+        {
+            "element": "container",
+            "data": {
+                "type": "paragraph",
+                "attributes": {},
+                "elements": [
+                    {
+                        "element": "text",
+                        "data": "MULTI"
+                    },
+                    {
+                        "element": "raw",
+                        "data": "\nfirst block\n"
+                    }
+                ]
+            }
+        },
+        {
+            "element": "container",
+            "data": {
+                "type": "paragraph",
+                "attributes": {},
+                "elements": [
+                    {
+                        "element": "raw",
+                        "data": "\nsecond block\n"
+                    }
+                ]
+            }
+        },
+        {
+            "element": "footnote-block",
+            "data": {
+                "title": null,
+                "hide": false
+            }
+        }
+    ]
+}


### PR DESCRIPTION
As an alternative to the two at sign-based methods of doing raw input (`@@` ... `@@` and `@<` ... `>@`) which are both inline, we can introduce a `[[raw]]` which accepts multiline unprocessed input. (cf [WJ-1269](https://scuttle.atlassian.net/browse/WJ-1269))

[WJ-1269]: https://scuttle.atlassian.net/browse/WJ-1269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ