### PR TITLE
Use built-in tomllib library

### DIFF
--- a/.github/workflows/config.yaml
+++ b/.github/workflows/config.yaml
@@ -23,10 +23,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Python 3.9
+      - name: Python 3.13
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.13
 
       - name: Pip Cache
         uses: actions/cache@v4

--- a/scripts/check_conf-requirements.txt
+++ b/scripts/check_conf-requirements.txt
@@ -1,2 +1,1 @@
 inflection>=0.5.0
-toml>=0.10.0

--- a/scripts/check_conf.py
+++ b/scripts/check_conf.py
@@ -6,7 +6,7 @@ import sys
 from collections import defaultdict
 
 import inflection
-import toml
+import tomllib
 
 EXCLUDE_BLOCKS = ["later"]
 EXCLUDE_MODULES = []
@@ -112,8 +112,8 @@ def load_block_data(root_dir):
     block_rules_path = os.path.join(root_dir, BLOCK_DIRECTORY)
 
     # Load config
-    with open(blocks_path) as file:
-        blocks = toml.load(file)
+    with open(blocks_path, "rb") as file:
+        blocks = tomllib.load(file)
 
         # Normalize module keys for case-insensitive access
         blocks = {convert_block_name(name): value for name, value in blocks.items()}
@@ -167,8 +167,8 @@ def load_module_data(root_dir):
     module_rules_path = os.path.join(root_dir, MODULE_DIRECTORY)
 
     # Load blocks
-    with open(modules_path) as file:
-        modules = toml.load(file)
+    with open(modules_path, "rb") as file:
+        modules = tomllib.load(file)
 
         # Normalize module keys for case-insensitive access
         modules = {convert_module_name(name): value for name, value in modules.items()}


### PR DESCRIPTION
As of [version 3.11, Python has in-built support for TOML in the form of the `tomllib` library](https://docs.python.org/3/library/tomllib.html). This switches the check script to use that instead of the prior third-party one.