### PR TITLE
Fix branch names in workflow files

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,8 +12,7 @@ on:
       - '.github/codecov.yml'
   push:
     branches:
-      - develop
-      - prod
+      - main
 
 jobs:
   library_build_and_test:
@@ -50,7 +49,7 @@ jobs:
 
       - name: Test (exhaustive)
         run: cd deepwell && cargo test --all-features -- --nocapture --ignored
-        if: github.ref == 'refs/head/develop' || github.ref == 'refs/head/prod'
+        if: github.ref == 'refs/head/main'
 
   wasm:
     name: WebASM

--- a/.github/workflows/config.yaml
+++ b/.github/workflows/config.yaml
@@ -12,8 +12,7 @@ on:
       - '.github/workflows/config.yaml'
   push:
     branches:
-      - develop
-      - prod
+      - main
 
 jobs:
   conf_check:


### PR DESCRIPTION
These are still `develop` and `prod` as holdovers from when this was in the Wikijump monorepo. This PR fixes them to be `main`, the main branch for this repo.