### PR TITLE
[WJ-1068] triple links generated from a label are now transliterated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ strum = "0.28"
 strum_macros = "0.28"
 time = { version = "0.3", features = ["formatting", "macros", "parsing", "serde", "serde-human-readable"], default-features = false }
 unicase = "2"
+unidecode = "0.3"
 wikidot-normalize = "0.12"
 writeable = "0.6"
 

--- a/src/data/page_ref.rs
+++ b/src/data/page_ref.rs
@@ -19,6 +19,7 @@
  */
 
 use std::fmt::{self, Display};
+use unidecode::unidecode;
 use wikidot_normalize::normalize;
 
 /// Represents a reference to a page on the wiki, as used by include notation.
@@ -71,8 +72,8 @@ impl PageRef {
         S2: AsRef<str>,
     {
         let (page, extra) = Self::split_page(page.as_ref());
-        let mut site = site.into();
-        let mut page = str!(page);
+        let mut site = unidecode(site.into().as_ref());
+        let mut page = unidecode(page);
         let extra = extra.map(String::from);
         normalize(&mut site);
         normalize(&mut page);
@@ -91,7 +92,7 @@ impl PageRef {
         S: AsRef<str>,
     {
         let (page, extra) = Self::split_page(page.as_ref());
-        let mut page = str!(page);
+        let mut page = unidecode(page);
         let extra = extra.map(String::from);
         normalize(&mut page);
         PageRef {
@@ -264,6 +265,16 @@ fn page_ref() {
         ":scp-wiki:deleted:secret:fragment:page",
         PageRef::page_and_site("scp-wiki", "deleted:secret:fragment:page"),
     );
+
+    // Transliteration (WJ-1068): non-ASCII page slugs are transliterated
+    // to ASCII so the generated URL is wikidot-compatible.
+    let translit = PageRef::parse("документ").expect("Cyrillic page name");
+    assert_eq!(translit.page(), "dokument");
+    assert_eq!(translit.site(), None);
+
+    let translit = PageRef::parse(":ru:документ").expect("Cyrillic on off-site");
+    assert_eq!(translit.site(), Some("ru"));
+    assert_eq!(translit.page(), "dokument");
 }
 
 #[cfg(test)]


### PR DESCRIPTION
see [WJ-1068](https://scuttle.atlassian.net/browse/WJ-1068)

I'm not 100% sure about my method for resolving this ticket; maybe you would have preferred changes in ``wikidot_normalize`` instead? 
Also let me know if the scope of the fix seems incorrect to you.

[WJ-1068]: https://scuttle.atlassian.net/browse/WJ-1068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ