### PR TITLE
fix: Rust 2024 edition lacks an explicit MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ exclude = [".gitignore", ".editorconfig"]
 version = "1.42.0"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2024"
+rust-version = "1.85.0"
 
 [lib]
 name = "ftml"


### PR DESCRIPTION
## Summary

- patch attempt: `pat_fnd-sig-feat-config-7afc533f22-7_651dd2b596`
- status: `applied`
- files changed: 1

## Findings

- `fnd_sig-feat-config-7afc533f22-78625_360fcda691`: Rust 2024 edition lacks an explicit MSRV (low)

## Changed Files

- `Cargo.toml`

## Validation

- `cargo fmt --all --check` => 0
- `cargo check --workspace --all-targets` => 0
- `cargo test --workspace` => 0

## Plan

Added an explicit `rust-version = "1.85.0"` to `Cargo.toml` to encode the minimum Rust toolchain implied by edition 2024.

