### PR TITLE
[Security] Fix XSS vulnerability in CSS module by escaping closing style tags

### DIFF
--- a/examples/validate_json.rs
+++ b/examples/validate_json.rs
@@ -116,7 +116,7 @@ enum Outcome {
 
 impl Outcome {
     fn write(&self, buffer: &mut Buffer, path: &Path) -> io::Result<()> {
-        buffer.set_color(&ColorSpec::new().set_bold(true).set_fg(Some(self.color())))?;
+        buffer.set_color(ColorSpec::new().set_bold(true).set_fg(Some(self.color())))?;
 
         match self {
             Outcome::Success(_) => write!(buffer, " pass")?,

--- a/src/render/html/element/style.rs
+++ b/src/render/html/element/style.rs
@@ -21,6 +21,40 @@
 use super::prelude::*;
 use lightningcss::stylesheet::{ParserOptions, PrinterOptions, StyleSheet};
 
+/// Prevent CSS from terminating the HTML `<style>` raw-text element.
+///
+/// This must run after CSS serialization: HTML parsing happens before the
+/// browser parses the CSS, so a CSS escape is needed rather than HTML
+/// escaping. The trailing space terminates the hexadecimal CSS escape.
+fn escape_style_end_tags(css: &str) -> String {
+    const END_TAG: &[u8] = b"</style";
+
+    let bytes = css.as_bytes();
+    let mut escaped = String::with_capacity(css.len());
+    let mut cursor = 0;
+
+    while cursor < bytes.len() {
+        let matches = cursor + END_TAG.len() <= bytes.len()
+            && bytes[cursor..cursor + END_TAG.len()]
+                .iter()
+                .zip(END_TAG.iter())
+                .all(|(&actual, &expected)| actual.eq_ignore_ascii_case(&expected));
+
+        if matches {
+            escaped.push_str(r"\3c /style");
+            cursor += END_TAG.len();
+        } else {
+            // `css` is valid UTF-8, so copying the next character rather than
+            // a byte keeps the result valid when non-ASCII CSS is present.
+            let character = css[cursor..].chars().next().expect("valid UTF-8");
+            escaped.push(character);
+            cursor += character.len_utf8();
+        }
+    }
+
+    escaped
+}
+
 pub fn render_style(ctx: &mut HtmlContext, input_css: &str) {
     let minify = ctx.settings().minify_css;
 
@@ -49,10 +83,38 @@ pub fn render_style(ctx: &mut HtmlContext, input_css: &str) {
         }
     };
 
+    let output_css = escape_style_end_tags(&output_css);
+
     ctx.html().style().inner(|ctx| {
-        // SAFETY: The resultant CSS cannot contain HTML-escaping elements,
-        //         as those are invalid and would not be retained during
-        //         the parcel_css parsing process.
+        // SAFETY: `escape_style_end_tags` prevents CSS from closing the
+        //         surrounding HTML style element before raw insertion.
         ctx.push_raw_str(&output_css);
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::escape_style_end_tags;
+
+    #[test]
+    fn escapes_style_end_tags_case_insensitively() {
+        assert_eq!(
+            escape_style_end_tags(r#"content: "</style><script>";"#),
+            r#"content: "\3c /style><script>";"#,
+        );
+        assert_eq!(
+            escape_style_end_tags(r#"content: "</STYLE><script>";"#),
+            r#"content: "\3c /style><script>";"#,
+        );
+        assert_eq!(
+            escape_style_end_tags(r#"content: "</StYlE >";"#),
+            r#"content: "\3c /style >";"#,
+        );
+    }
+
+    #[test]
+    fn leaves_other_css_untouched() {
+        let css = r#"@media (width < 600px) { x { content: "</st yle>"; } }"#;
+        assert_eq!(escape_style_end_tags(css), css);
+    }
 }

--- a/src/render/html/element/style.rs
+++ b/src/render/html/element/style.rs
@@ -28,7 +28,7 @@ use lightningcss::stylesheet::{ParserOptions, PrinterOptions, StyleSheet};
 /// escaping. The trailing space terminates the hexadecimal CSS escape.
 fn escape_style_end_tags(css: &mut String) {
     const HTML_END_TAG_START: &str = "</";
-    const CSS_ESCAPED_END_TAG_START: &str = r"\3c /";
+    const CSS_ESCAPED_END_TAG_START: &str = r"\3c/";
 
     let mut offset = 0;
     while let Some(relative_start) = css[offset..].find(HTML_END_TAG_START) {

--- a/src/render/html/element/style.rs
+++ b/src/render/html/element/style.rs
@@ -73,8 +73,10 @@ pub fn render_style(ctx: &mut HtmlContext, input_css: &str) {
     escape_style_end_tags(&mut output_css);
 
     ctx.html().style().inner(|ctx| {
-        // SAFETY: `escape_style_end_tags` prevents CSS from closing the
-        //         surrounding HTML style element before raw insertion.
+        // SAFETY: LightningCSS parses and serializes the stylesheet removing
+        //         invalid CSS constructs. `escape_style_end_tags` additionally
+        //         neutralizes any `</` retained in valid CSS so raw insertion
+        //         cannot terminate the surrounding HTML `<style>` element.
         ctx.push_raw_str(&output_css);
     });
 }

--- a/src/render/html/element/style.rs
+++ b/src/render/html/element/style.rs
@@ -26,33 +26,19 @@ use lightningcss::stylesheet::{ParserOptions, PrinterOptions, StyleSheet};
 /// This must run after CSS serialization: HTML parsing happens before the
 /// browser parses the CSS, so a CSS escape is needed rather than HTML
 /// escaping. The trailing space terminates the hexadecimal CSS escape.
-fn escape_style_end_tags(css: &str) -> String {
-    const END_TAG: &[u8] = b"</style";
+fn escape_style_end_tags(css: &mut String) {
+    const HTML_END_TAG_START: &str = "</";
+    const CSS_ESCAPED_END_TAG_START: &str = r"\3c /";
 
-    let bytes = css.as_bytes();
-    let mut escaped = String::with_capacity(css.len());
-    let mut cursor = 0;
-
-    while cursor < bytes.len() {
-        let matches = cursor + END_TAG.len() <= bytes.len()
-            && bytes[cursor..cursor + END_TAG.len()]
-                .iter()
-                .zip(END_TAG.iter())
-                .all(|(&actual, &expected)| actual.eq_ignore_ascii_case(&expected));
-
-        if matches {
-            escaped.push_str(r"\3c /style");
-            cursor += END_TAG.len();
-        } else {
-            // `css` is valid UTF-8, so copying the next character rather than
-            // a byte keeps the result valid when non-ASCII CSS is present.
-            let character = css[cursor..].chars().next().expect("valid UTF-8");
-            escaped.push(character);
-            cursor += character.len_utf8();
-        }
+    let mut offset = 0;
+    while let Some(relative_start) = css[offset..].find(HTML_END_TAG_START) {
+        let start = offset + relative_start;
+        css.replace_range(
+            start..start + HTML_END_TAG_START.len(),
+            CSS_ESCAPED_END_TAG_START,
+        );
+        offset = start + CSS_ESCAPED_END_TAG_START.len();
     }
-
-    escaped
 }
 
 pub fn render_style(ctx: &mut HtmlContext, input_css: &str) {
@@ -83,7 +69,8 @@ pub fn render_style(ctx: &mut HtmlContext, input_css: &str) {
         }
     };
 
-    let output_css = escape_style_end_tags(&output_css);
+    let mut output_css = output_css;
+    escape_style_end_tags(&mut output_css);
 
     ctx.html().style().inner(|ctx| {
         // SAFETY: `escape_style_end_tags` prevents CSS from closing the
@@ -96,25 +83,47 @@ pub fn render_style(ctx: &mut HtmlContext, input_css: &str) {
 mod tests {
     use super::escape_style_end_tags;
 
+    fn escaped(css: &str) -> String {
+        let mut css = css.to_owned();
+        escape_style_end_tags(&mut css);
+        css
+    }
+
     #[test]
-    fn escapes_style_end_tags_case_insensitively() {
+    fn escapes_any_html_end_tag_start() {
         assert_eq!(
-            escape_style_end_tags(r#"content: "</style><script>";"#),
+            escaped(r#"content: "</style><script>";"#),
             r#"content: "\3c /style><script>";"#,
         );
         assert_eq!(
-            escape_style_end_tags(r#"content: "</STYLE><script>";"#),
-            r#"content: "\3c /style><script>";"#,
+            escaped(r#"content: "</script>";"#),
+            r#"content: "\3c /script>";"#,
         );
         assert_eq!(
-            escape_style_end_tags(r#"content: "</StYlE >";"#),
-            r#"content: "\3c /style >";"#,
+            escaped(r#"content: "</ style>";"#),
+            r#"content: "\3c / style>";"#,
         );
     }
 
     #[test]
-    fn leaves_other_css_untouched() {
-        let css = r#"@media (width < 600px) { x { content: "</st yle>"; } }"#;
-        assert_eq!(escape_style_end_tags(css), css);
+    fn escapes_the_style_terminator_exactly() {
+        assert_eq!(
+            escaped(r#"x { content: "</style"; }"#),
+            r#"x { content: "\3c /style"; }"#,
+        );
+    }
+
+    #[test]
+    fn preserves_non_ascii_css() {
+        assert_eq!(
+            escaped(r#"x { content: "café </style>"; }"#),
+            r#"x { content: "café \3c /style>"; }"#,
+        );
+    }
+
+    #[test]
+    fn leaves_css_without_html_end_tag_start_untouched() {
+        let css = r#"@media (width < 600px) { x { content: "< /style>"; } }"#;
+        assert_eq!(escaped(css), css);
     }
 }

--- a/src/render/html/element/style.rs
+++ b/src/render/html/element/style.rs
@@ -30,14 +30,15 @@ fn escape_style_end_tags(css: &mut String) {
     const HTML_END_TAG_START: &str = "</";
     const CSS_ESCAPED_END_TAG_START: &str = r"\3c/";
 
+    replace_all(css, HTML_END_TAG_START, CSS_ESCAPED_END_TAG_START);
+}
+
+fn replace_all(string: &mut String, pattern: &str, replacement: &str) {
     let mut offset = 0;
-    while let Some(relative_start) = css[offset..].find(HTML_END_TAG_START) {
+    while let Some(relative_start) = string[offset..].find(pattern) {
         let start = offset + relative_start;
-        css.replace_range(
-            start..start + HTML_END_TAG_START.len(),
-            CSS_ESCAPED_END_TAG_START,
-        );
-        offset = start + CSS_ESCAPED_END_TAG_START.len();
+        string.replace_range(start..start + pattern.len(), replacement);
+        offset = start + replacement.len();
     }
 }
 

--- a/src/render/html/element/style.rs
+++ b/src/render/html/element/style.rs
@@ -22,10 +22,6 @@ use super::prelude::*;
 use lightningcss::stylesheet::{ParserOptions, PrinterOptions, StyleSheet};
 
 /// Prevent CSS from terminating the HTML `<style>` raw-text element.
-///
-/// This must run after CSS serialization: HTML parsing happens before the
-/// browser parses the CSS, so a CSS escape is needed rather than HTML
-/// escaping. The trailing space terminates the hexadecimal CSS escape.
 fn escape_style_end_tags(css: &mut String) {
     const HTML_END_TAG_START: &str = "</";
     const CSS_ESCAPED_END_TAG_START: &str = r"\3c/";


### PR DESCRIPTION
Fixes a stored XSS vulnerability in the FTML `[[module CSS]]` module

User-controlled CSS was serialized and inserted directly into a `<style>` element without protecting against the HTML sequence `</style>`

## POC
```css
[[module CSS]]x{content:"</style><script>alert(1)</script>"}[[/module]]
```