### PR TITLE
Use new regex! macro where possible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ pest = "2"
 pest_derive = "2"
 rand = "0.10"
 ref-map = "0.2"
-regex = "1"
+regex = "1.13"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/src/includes/mod.rs
+++ b/src/includes/mod.rs
@@ -42,17 +42,6 @@ use crate::tree::VariableMap;
 use regex::{Regex, RegexBuilder};
 use std::sync::LazyLock;
 
-static INCLUDE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    RegexBuilder::new(r"^\[\[\s*include\s+")
-        .case_insensitive(true)
-        .multi_line(true)
-        .dot_matches_new_line(true)
-        .build()
-        .unwrap()
-});
-static VARIABLE_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\{\$(?P<name>[a-zA-Z0-9_\-]+)\}").unwrap());
-
 /// Replaces the include blocks in a string with the content of the pages referenced by those
 /// blocks.
 pub fn include<'t, I, E, F>(
@@ -65,6 +54,15 @@ where
     I: Includer<'t, Error = E>,
     F: FnOnce() -> E,
 {
+    static INCLUDE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+        RegexBuilder::new(r"^\[\[\s*include\s+")
+            .case_insensitive(true)
+            .multi_line(true)
+            .dot_matches_new_line(true)
+            .build()
+            .unwrap()
+    });
+
     if !settings.enable_page_syntax {
         debug!("Includes are disabled for this input, skipping");
 
@@ -167,9 +165,10 @@ where
 /// Read <https://www.wikidot.com/doc-wiki-syntax:include> for more details.
 fn replace_variables(content: &mut String, variables: &VariableMap) {
     let mut matches = Vec::new();
+    let variable_regex = regex!(r"\{\$(?P<name>[a-zA-Z0-9_\-]+)\}");
 
     // Find all variables
-    for capture in VARIABLE_REGEX.captures_iter(content) {
+    for capture in variable_regex.captures_iter(content) {
         let mtch = capture.get(0).unwrap();
         let name = &capture["name"];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,9 @@ extern crate maplit;
 extern crate pest_derive;
 
 #[macro_use]
+extern crate regex;
+
+#[macro_use]
 extern crate serde;
 
 #[macro_use]

--- a/src/parsing/rule/impls/block/blocks/date.rs
+++ b/src/parsing/rule/impls/block/blocks/date.rs
@@ -20,9 +20,7 @@
 
 use super::prelude::*;
 use crate::tree::DateItem;
-use regex::Regex;
 use std::borrow::Cow;
-use std::sync::LazyLock;
 use time::format_description::well_known::{Iso8601, Rfc2822, Rfc3339};
 use time::{Date, OffsetDateTime, PrimitiveDateTime, UtcOffset};
 
@@ -159,13 +157,11 @@ fn parse_date(value: &str) -> Result<DateItem, DateParseError> {
 
 /// Parse the timezone based on the specifier string.
 fn parse_timezone(value: &str) -> Result<UtcOffset, DateParseError> {
-    static TIMEZONE_REGEX: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"^(\+|-)?([0-9]{1,2}):?([0-9]{2})?$").unwrap());
-
     debug!("Parsing possible timezone value '{value}'");
 
     // Try hours / minutes (via regex)
-    if let Some(captures) = TIMEZONE_REGEX.captures(value) {
+    let timezone_regex = regex!(r"^(\+|-)?([0-9]{1,2}):?([0-9]{2})?$");
+    if let Some(captures) = timezone_regex.captures(value) {
         // Get sign (+1 or -1)
         let sign = match captures.get(1) {
             None => 1,

--- a/src/parsing/rule/impls/block/parser.rs
+++ b/src/parsing/rule/impls/block/parser.rs
@@ -28,11 +28,6 @@ use crate::parsing::{
     gather_paragraphs,
 };
 use crate::tree::Element;
-use regex::Regex;
-use std::sync::LazyLock;
-
-static ARGUMENT_KEY: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"[A-Za-z0-9_\-]+").unwrap());
 
 impl<'r, 't> Parser<'r, 't>
 where
@@ -291,6 +286,7 @@ where
                 let key = {
                     let start = self.current();
                     let mut args_finished = false;
+                    let argument_key_regex = regex!(r"[A-Za-z0-9_\-]+");
 
                     loop {
                         let current = self.current();
@@ -308,7 +304,7 @@ where
                             | Token::Equals => break,
 
                             // Continue iterating to gather key
-                            _ if ARGUMENT_KEY.is_match(current.slice) => {
+                            _ if argument_key_regex.is_match(current.slice) => {
                                 self.step()?;
                             }
 

--- a/src/parsing/rule/impls/color.rs
+++ b/src/parsing/rule/impls/color.rs
@@ -19,12 +19,7 @@
  */
 
 use super::prelude::*;
-use regex::Regex;
 use std::borrow::Cow;
-use std::sync::LazyLock;
-
-static HEX_COLOR: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$").unwrap());
 
 pub const RULE_COLOR: Rule = Rule {
     name: "color",
@@ -80,7 +75,8 @@ fn try_consume_fn<'r, 't>(
 /// but if a hex specification is passed, and it doesn't already begin with
 /// `#`, then one should be prepended.
 fn hexify_color(color: &str) -> Cow<'_, str> {
-    if HEX_COLOR.is_match(color) {
+    let hex_color_regex = regex!(r"^([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$");
+    if hex_color_regex.is_match(color) {
         Cow::Owned(format!("#{color}"))
     } else {
         Cow::Borrowed(color)

--- a/src/parsing/rule/impls/variable.rs
+++ b/src/parsing/rule/impls/variable.rs
@@ -19,11 +19,6 @@
  */
 
 use super::prelude::*;
-use regex::Regex;
-use std::sync::LazyLock;
-
-static VARIABLE_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\{\$(.+)\}").unwrap());
 
 pub const RULE_VARIABLE: Rule = Rule {
     name: "variable",
@@ -37,8 +32,7 @@ fn try_consume_fn<'r, 't>(
     debug!("Consuming token by placing variable contents");
 
     let ExtractedToken { slice, .. } = parser.current();
-
-    let variable = VARIABLE_REGEX
+    let variable = regex!(r"\{\$(.+)\}")
         .captures(slice)
         .expect("Variable regex didn't match")
         .get(1)

--- a/src/tree/align.rs
+++ b/src/tree/align.rs
@@ -18,7 +18,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use regex::Regex;
 use std::convert::TryFrom;
 
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -82,12 +81,7 @@ pub struct FloatAlignment {
 
 impl FloatAlignment {
     pub fn parse(name: &str) -> Option<Self> {
-        use std::sync::LazyLock;
-
-        static IMAGE_ALIGNMENT_REGEX: LazyLock<Regex> =
-            LazyLock::new(|| Regex::new(r"^[fF]?([<=>])").unwrap());
-
-        IMAGE_ALIGNMENT_REGEX
+        regex!(r"^[fF]?([<=>])")
             .find(name)
             .and_then(|mtch| FloatAlignment::try_from(mtch.as_str()).ok())
     }

--- a/src/tree/attribute/safe.rs
+++ b/src/tree/attribute/safe.rs
@@ -18,7 +18,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use regex::Regex;
 use std::collections::HashSet;
 use std::sync::LazyLock;
 use unicase::UniCase;
@@ -184,9 +183,6 @@ pub static BOOLEAN_ATTRIBUTES: LazyLock<HashSet<UniCase<&'static str>>> =
 pub static URL_ATTRIBUTES: LazyLock<HashSet<UniCase<&'static str>>> =
     LazyLock::new(|| hashset_unicase!["href", "src"]);
 
-static ATTRIBUTE_SUFFIX_SAFE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"[a-zA-z0-9\-]+").unwrap());
-
 pub const SAFE_ATTRIBUTE_PREFIXES: [&str; 2] = ["aria-", "data-"];
 
 pub fn is_safe_attribute(attribute: UniCase<&str>) -> bool {
@@ -194,8 +190,9 @@ pub fn is_safe_attribute(attribute: UniCase<&str>) -> bool {
         return true;
     }
 
+    let attribute_suffix_safe = regex!(r"[a-zA-z0-9\-]+");
     for prefix in &SAFE_ATTRIBUTE_PREFIXES {
-        if attribute.starts_with(prefix) && ATTRIBUTE_SUFFIX_SAFE.is_match(&attribute) {
+        if attribute.starts_with(prefix) && attribute_suffix_safe.is_match(&attribute) {
             return true;
         }
     }


### PR DESCRIPTION
This new macro avoids the need for explicit `LazyLock<Regex>` in several places, which is highly convenient and makes the regex being used more obvious.