### PR TITLE
Reinstate wasm typescript types

### DIFF
--- a/src/wasm/page_info.rs
+++ b/src/wasm/page_info.rs
@@ -23,6 +23,33 @@ use crate::data::PageInfo as RustPageInfo;
 use ref_map::*;
 use std::sync::Arc;
 
+// Typescript declarations
+
+#[wasm_bindgen(typescript_custom_section)]
+const TS_APPEND_CONTENT: &str = r#"
+export interface IPageInfo {
+    page: string;
+    category: string | null;
+    site: string;
+    title: string;
+    alt_title: string | null;
+    score: number;
+    tags: string[];
+    language: string;
+}
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "IPageInfo")]
+    pub type IPageInfo;
+
+    #[wasm_bindgen(typescript_type = "string[]")]
+    pub type ITags;
+}
+
+// Wrapper structure
+
 #[wasm_bindgen]
 #[derive(Debug, Clone)]
 pub struct PageInfo {
@@ -44,7 +71,9 @@ impl PageInfo {
     }
 
     #[wasm_bindgen(constructor)]
-    pub fn new(info: JsValue) -> Result<PageInfo, JsValue> {
+    pub fn new(info: IPageInfo) -> Result<PageInfo, JsValue> {
+        let info: JsValue = info.into();
+
         Ok(PageInfo {
             inner: Arc::new(js_to_rust!(info)?),
         })
@@ -83,8 +112,8 @@ impl PageInfo {
     }
 
     #[wasm_bindgen(getter)]
-    pub fn tags(&self) -> Result<JsValue, JsValue> {
-        rust_to_js!(self.inner.tags)
+    pub fn tags(&self) -> Result<ITags, JsValue> {
+        rust_to_js!(self.inner.tags).map(|tags| tags.into())
     }
 
     #[wasm_bindgen(getter)]

--- a/src/wasm/parsing.rs
+++ b/src/wasm/parsing.rs
@@ -28,6 +28,43 @@ use crate::tree::SyntaxTree as RustSyntaxTree;
 use crate::utf16::Utf16IndexMap;
 use std::sync::Arc;
 
+// Typescript declarations
+
+#[wasm_bindgen(typescript_custom_section)]
+const TS_APPEND_CONTENT: &str = r#"
+export interface IElement {
+    element: string;
+    data?: any;
+}
+
+export interface ISyntaxTree {
+    elements: IElement[];
+    table_of_contents: IElement[];
+    footnotes: IElement[][];
+}
+
+export interface IParseError {
+    token: string;
+    rule: string;
+    span: {
+        start: number;
+        end: number;
+    };
+    kind: string;
+}
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "ISyntaxTree")]
+    pub type ISyntaxTree;
+
+    #[wasm_bindgen(typescript_type = "IParseError[]")]
+    pub type IParseErrorArray;
+}
+
+// Wrapper structures
+
 #[wasm_bindgen]
 #[derive(Debug, Clone)]
 pub struct ParseOutcome {
@@ -53,8 +90,8 @@ impl ParseOutcome {
     }
 
     #[wasm_bindgen]
-    pub fn errors(&self) -> Result<JsValue, JsValue> {
-        rust_to_js!(self.inner.errors())
+    pub fn errors(&self) -> Result<IParseErrorArray, JsValue> {
+        rust_to_js!(self.inner.errors()).map(|err| err.into())
     }
 }
 
@@ -79,8 +116,8 @@ impl SyntaxTree {
     }
 
     #[wasm_bindgen]
-    pub fn data(&self) -> Result<JsValue, JsValue> {
-        rust_to_js!(*self.inner)
+    pub fn data(&self) -> Result<ISyntaxTree, JsValue> {
+        rust_to_js!(*self.inner).map(|data| data.into())
     }
 }
 

--- a/src/wasm/render/html.rs
+++ b/src/wasm/render/html.rs
@@ -31,6 +31,43 @@ use crate::render::Render;
 use crate::render::html::{HtmlOutput as RustHtmlOutput, HtmlRender};
 use std::sync::Arc;
 
+// Typescript declarations
+
+#[wasm_bindgen(typescript_custom_section)]
+const TS_APPEND_CONTENT: &str = r#"
+export interface IHtmlOutput {
+    body: string;
+    style: string;
+    meta: IHtmlMeta[];
+}
+
+export interface IHtmlMeta {
+    tag_type: string;
+    name: string;
+    value: string;
+}
+
+export interface IBacklinks {
+    included_pages: string[];
+    internal_links: string[];
+    external_links: string[];
+}
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "string[]")]
+    pub type IStyleArray;
+
+    #[wasm_bindgen(typescript_type = "IHtmlMeta[]")]
+    pub type IHtmlMetaArray;
+
+    #[wasm_bindgen(typescript_type = "IBacklinks")]
+    pub type IBacklinks;
+}
+
+// Wrapper structures
+
 #[wasm_bindgen]
 #[derive(Debug, Clone)]
 pub struct HtmlOutput {
@@ -52,13 +89,13 @@ impl HtmlOutput {
     }
 
     #[wasm_bindgen]
-    pub fn html_meta(&self) -> Result<JsValue, JsValue> {
-        rust_to_js!(self.inner.meta)
+    pub fn html_meta(&self) -> Result<IHtmlMetaArray, JsValue> {
+        rust_to_js!(self.inner.meta).map(|meta| meta.into())
     }
 
     #[wasm_bindgen]
-    pub fn backlinks(&self) -> Result<JsValue, JsValue> {
-        rust_to_js!(self.inner.backlinks)
+    pub fn backlinks(&self) -> Result<IBacklinks, JsValue> {
+        rust_to_js!(self.inner.backlinks).map(|backlinks| backlinks.into())
     }
 }
 

--- a/src/wasm/settings.rs
+++ b/src/wasm/settings.rs
@@ -25,6 +25,33 @@ use crate::settings::{
 };
 use std::sync::Arc;
 
+// Typescript declarations
+
+#[wasm_bindgen(typescript_custom_section)]
+const TS_APPEND_CONTENT: &str = r#"
+export interface IWikitextSettings {
+    mode: WikitextMode;
+    enable_page_syntax: boolean;
+    use_true_ids: boolean;
+    allow_local_paths: boolean;
+}
+
+export type WikitextMode =
+    | 'page'
+    | 'draft'
+    | 'forum-post'
+    | 'direct-message'
+    | 'list'
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "IWikitextSettings")]
+    pub type IWikitextSettings;
+}
+
+// Wrapper structure
+
 #[wasm_bindgen]
 #[derive(Debug, Clone)]
 pub struct WikitextSettings {
@@ -46,7 +73,9 @@ impl WikitextSettings {
     }
 
     #[wasm_bindgen(constructor)]
-    pub fn new(settings: JsValue) -> Result<WikitextSettings, JsValue> {
+    pub fn new(settings: IWikitextSettings) -> Result<WikitextSettings, JsValue> {
+        let settings: JsValue = settings.into();
+
         Ok(WikitextSettings {
             inner: Arc::new(js_to_rust!(settings)?),
         })

--- a/src/wasm/tokenizer.rs
+++ b/src/wasm/tokenizer.rs
@@ -25,6 +25,28 @@ use crate::utf16::Utf16IndexMap;
 use self_cell::self_cell;
 use std::sync::Arc;
 
+// Typescript declarations
+
+#[wasm_bindgen(typescript_custom_section)]
+const TS_APPEND_CONTENT: &str = r#"
+export interface IToken {
+    token: string;
+    slice: string;
+    span: {
+        start: number;
+        end: number;
+    };
+}
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "IToken[]")]
+    pub type ITokenArray;
+}
+
+// Wrapper structures
+
 self_cell!(
     struct TokenizationInner {
         owner: String,
@@ -62,9 +84,10 @@ impl Tokenization {
     }
 
     #[wasm_bindgen]
-    pub fn tokens(&self) -> Result<JsValue, JsValue> {
-        self.inner
-            .with_dependent(|_, inner| rust_to_js!(convert_tokens_utf16(inner)))
+    pub fn tokens(&self) -> Result<ITokenArray, JsValue> {
+        self.inner.with_dependent(|_, inner| {
+            rust_to_js!(convert_tokens_utf16(inner)).map(|tokens| tokens.into())
+        })
     }
 }
 


### PR DESCRIPTION
Brings back typescript types for wasm builds.

The problem back when the types were removed seems to be `wasm-bindgen` typescript attributes only being valid within `extern "C"` blocks, whereas in our previous code they were used outside the blocks too, so the checker generated unused variable warnings.